### PR TITLE
Update CIBuild.yml

### DIFF
--- a/.github/workflows/CIBuild.yml
+++ b/.github/workflows/CIBuild.yml
@@ -23,7 +23,12 @@ jobs:
     
     - name: Setup Visual Studio Command Prompt
       uses: microsoft/setup-msbuild@v2.0.0
-      
+
+    - name: Setup .NET 9.x
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: '9.0.100'
+        
     - name: Build WPF
       run: |
         msbuild /restore /t:Build src\Esri.Calcite.WPF\Esri.Calcite.WPF.csproj /p:Configuration=Release


### PR DESCRIPTION
Ensures we build with lowest .NET 9 SDK (9.0.100) for compatibility with older SDKs too (crashes on Maui-Windows if using something older than what was built with)