### PR TITLE
Add missing icons

### DIFF
--- a/GeneratedResources/Maui/CalciteIcon.cs
+++ b/GeneratedResources/Maui/CalciteIcon.cs
@@ -206,6 +206,12 @@ public enum CalciteIcon : ushort
 	/// <release>3.0.0</release>
 	AddressBook = 59167,
 
+	/// <summary>Alert Off Circle (Filled)</summary>
+	/// <remarks>Category: Objects<br/>
+	/// Alias: 3.24.2, objects, bell, no notifications, silent, vibrate, unsubscribe, turn off, no alarm, no announcements, filled</remarks>
+	/// <release>3.24.2</release>
+	AlertOffCircleFilled = 59168,
+
 	/// <summary>All Servers</summary>
 	/// <remarks>Category: GIS<br/>
 	/// Alias: 3.20.7, gis, connections, connected, networks</remarks>
@@ -530,11 +536,23 @@ public enum CalciteIcon : ushort
 	/// <release>1.5</release>
 	BearRight = 59222,
 
+	/// <summary>Beginning (Filled)</summary>
+	/// <remarks>Category: Media<br/>
+	/// Alias: 1.5.0, start, first, media, filled</remarks>
+	/// <release>1.5</release>
+	BeginningFilled = 59223,
+
 	/// <summary>Beginning</summary>
 	/// <remarks>Category: Media<br/>
 	/// Alias: 1.5.0, start, first, media</remarks>
 	/// <release>1.5</release>
 	Beginning = 59224,
+
+	/// <summary>Bell (Filled)</summary>
+	/// <remarks>Category: Objects<br/>
+	/// Alias: 3.14.5, objects, notification, alert, alarm, bell, filled</remarks>
+	/// <release>3.14.5</release>
+	BellFilled = 59225,
 
 	/// <summary>Bell</summary>
 	/// <remarks>Category: Objects<br/>
@@ -884,6 +902,12 @@ public enum CalciteIcon : ushort
 	/// <release>1.5</release>
 	Check = 59283,
 
+	/// <summary>Check Circle (Filled)</summary>
+	/// <remarks>Category: Symbols<br/>
+	/// Alias: 1.5.0, symbols, check, mark, selected, circle, filled</remarks>
+	/// <release>1.5</release>
+	CheckCircleFilled = 59284,
+
 	/// <summary>Check Circle</summary>
 	/// <remarks>Category: Symbols<br/>
 	/// Alias: 1.5.0, symbols, check, mark, selected, circle</remarks>
@@ -907,6 +931,12 @@ public enum CalciteIcon : ushort
 	/// Alias: 3.15.2, objects, safety, insurance, protection, insured, secure, security, anti-virus, cybersecurity, defense, protected, warranty, coverage</remarks>
 	/// <release>3.15.2</release>
 	CheckShield = 59288,
+
+	/// <summary>Check Square (Filled)</summary>
+	/// <remarks>Category: Symbols<br/>
+	/// Alias: 1.5.0, symbols, done, box, select, tick, check mark, toggle, confirm, correct, selected, filled</remarks>
+	/// <release>1.5</release>
+	CheckSquareFilled = 59289,
 
 	/// <summary>Check Square</summary>
 	/// <remarks>Category: Symbols<br/>
@@ -1004,6 +1034,12 @@ public enum CalciteIcon : ushort
 	/// <release>1.5</release>
 	ChordDiagram = 59305,
 
+	/// <summary>Circle (Filled)</summary>
+	/// <remarks>Category: Generic<br/>
+	/// Alias: 1.5.0, generic, radio, shape, empty, button, filled</remarks>
+	/// <release>1.5</release>
+	CircleFilled = 59306,
+
 	/// <summary>Circle</summary>
 	/// <remarks>Category: Generic<br/>
 	/// Alias: 1.5.0, generic, radio, shape, empty, button</remarks>
@@ -1034,11 +1070,23 @@ public enum CalciteIcon : ushort
 	/// <release>3.28.8</release>
 	CircleInsetSmall = 59311,
 
+	/// <summary>Circle Pause (Filled)</summary>
+	/// <remarks>Category: Symbols<br/>
+	/// Alias: 3.23.0, symbols, stop, hold, pausing, waiting, slow, status, filled</remarks>
+	/// <release>3.23.0</release>
+	CirclePauseFilled = 59312,
+
 	/// <summary>Circle Pause</summary>
 	/// <remarks>Category: Symbols<br/>
 	/// Alias: 3.23.0, symbols, stop, hold, pausing, waiting, slow, status</remarks>
 	/// <release>3.23.0</release>
 	CirclePause = 59313,
+
+	/// <summary>Circle Stop (Filled)</summary>
+	/// <remarks>Category: Symbols<br/>
+	/// Alias: 3.24.1, symbols, cube, stop, halt, end, finish, button, filled</remarks>
+	/// <release>3.24.1</release>
+	CircleStopFilled = 59314,
 
 	/// <summary>Circle Stop</summary>
 	/// <remarks>Category: Symbols<br/>
@@ -1093,6 +1141,12 @@ public enum CalciteIcon : ushort
 	/// Alias: 1.5.0, objects, time, date, sort, ascending</remarks>
 	/// <release>1.5</release>
 	ClockUp = 59323,
+
+	/// <summary>Closed Caption (Filled)</summary>
+	/// <remarks>Category: Media<br/>
+	/// Alias: 3.29.3, media, media, audio, video, display, text, information, filled</remarks>
+	/// <release>3.29.3</release>
+	ClosedCaptionFilled = 59324,
 
 	/// <summary>Closed Caption</summary>
 	/// <remarks>Category: Media<br/>
@@ -1850,6 +1904,12 @@ public enum CalciteIcon : ushort
 	/// <release>3.25.2</release>
 	EnableDisableFeatureSelection = 59450,
 
+	/// <summary>End (Filled)</summary>
+	/// <remarks>Category: Media<br/>
+	/// Alias: 1.5.0, media, filled</remarks>
+	/// <release>1.5</release>
+	EndFilled = 59451,
+
 	/// <summary>End</summary>
 	/// <remarks>Category: Media<br/>
 	/// Alias: 1.5.0, media</remarks>
@@ -1892,11 +1952,23 @@ public enum CalciteIcon : ushort
 	/// <release>3.0.0</release>
 	Event = 59458,
 
+	/// <summary>Exclamation Mark Circle (Filled)</summary>
+	/// <remarks>Category: Symbols<br/>
+	/// Alias: 1.5.0, symbols, invalid, error, broken, filled</remarks>
+	/// <release>1.5</release>
+	ExclamationMarkCircleFilled = 59459,
+
 	/// <summary>Exclamation Mark Circle</summary>
 	/// <remarks>Category: Symbols<br/>
 	/// Alias: 1.5.0, symbols, invalid, error, broken</remarks>
 	/// <release>1.5</release>
 	ExclamationMarkCircle = 59460,
+
+	/// <summary>Exclamation Mark Triangle (Filled)</summary>
+	/// <remarks>Category: Symbols<br/>
+	/// Alias: 1.5.0, symbols, warning, alert, filled</remarks>
+	/// <release>1.5</release>
+	ExclamationMarkTriangleFilled = 59461,
 
 	/// <summary>Exclamation Mark Triangle</summary>
 	/// <remarks>Category: Symbols<br/>
@@ -2180,6 +2252,12 @@ public enum CalciteIcon : ushort
 	/// <release>3.17.0</release>
 	Fingerprint = 59508,
 
+	/// <summary>Flag (Filled)</summary>
+	/// <remarks>Category: Objects<br/>
+	/// Alias: 3.29.1, objects, signal, flag, sign, important, warning, alert, caution, filled</remarks>
+	/// <release>3.29.1</release>
+	FlagFilled = 59509,
+
 	/// <summary>Flag</summary>
 	/// <remarks>Category: Objects<br/>
 	/// Alias: 3.29.1, objects, signal, flag, sign, important, warning, alert, caution</remarks>
@@ -2378,6 +2456,12 @@ public enum CalciteIcon : ushort
 	/// <release>3.16.6</release>
 	FormFieldOff = 59542,
 
+	/// <summary>Forward (Filled)</summary>
+	/// <remarks>Category: Media<br/>
+	/// Alias: 1.5.0, media, filled</remarks>
+	/// <release>1.5</release>
+	ForwardFilled = 59543,
+
 	/// <summary>Forward</summary>
 	/// <remarks>Category: Media<br/>
 	/// Alias: 1.5.0, media</remarks>
@@ -2503,6 +2587,12 @@ public enum CalciteIcon : ushort
 	/// Alias: 1.5.0, gis, locate, current location, tracking</remarks>
 	/// <release>1.5</release>
 	GpsOff = 59564,
+
+	/// <summary>Gps On (Filled)</summary>
+	/// <remarks>Category: GIS<br/>
+	/// Alias: 1.5.0, gis, locate, current location, tracking, filled</remarks>
+	/// <release>1.5</release>
+	GpsOnFilled = 59565,
 
 	/// <summary>Gps On</summary>
 	/// <remarks>Category: GIS<br/>
@@ -2701,6 +2791,12 @@ public enum CalciteIcon : ushort
 	/// Alias: 1.5.0, objects, headphones, customer, service, representative, support</remarks>
 	/// <release>1.5</release>
 	Headset = 59598,
+
+	/// <summary>Heart (Filled)</summary>
+	/// <remarks>Category: Generic<br/>
+	/// Alias: 3.19.9, generic, shape, love, favorite, valentine, gift, like, filled</remarks>
+	/// <release>3.19.9</release>
+	HeartFilled = 59599,
 
 	/// <summary>Heart</summary>
 	/// <remarks>Category: Generic<br/>
@@ -2941,6 +3037,12 @@ public enum CalciteIcon : ushort
 	/// Alias: 1.5.0, generic, shapes, visualization</remarks>
 	/// <release>1.5</release>
 	Infographic = 59639,
+
+	/// <summary>Information (Filled)</summary>
+	/// <remarks>Category: Symbols<br/>
+	/// Alias: 1.5.0, symbols, about, help, tooltip, filled</remarks>
+	/// <release>1.5</release>
+	InformationFilled = 59640,
 
 	/// <summary>Information</summary>
 	/// <remarks>Category: Symbols<br/>
@@ -3524,6 +3626,12 @@ public enum CalciteIcon : ushort
 	/// <release>2.7.0</release>
 	Locator = 59737,
 
+	/// <summary>Lock (Filled)</summary>
+	/// <remarks>Category: Objects<br/>
+	/// Alias: 1.5.0, objects, secure, guarded, permission, security, restricted, privacy, filled</remarks>
+	/// <release>1.5</release>
+	LockFilled = 59738,
+
 	/// <summary>Lock</summary>
 	/// <remarks>Category: Objects<br/>
 	/// Alias: 1.5.0, objects, secure, guarded, permission, security, restricted, privacy</remarks>
@@ -3770,11 +3878,23 @@ public enum CalciteIcon : ushort
 	/// <release>1.5</release>
 	Minus = 59779,
 
+	/// <summary>Minus Circle (Filled)</summary>
+	/// <remarks>Category: Symbols<br/>
+	/// Alias: 3.24.2, symbols, stop, delete, remove, restricted, subtract, filled</remarks>
+	/// <release>3.24.2</release>
+	MinusCircleFilled = 59780,
+
 	/// <summary>Minus Circle</summary>
 	/// <remarks>Category: Symbols<br/>
 	/// Alias: 3.24.2, symbols, stop, delete, remove, restricted, subtract</remarks>
 	/// <release>3.24.2</release>
 	MinusCircle = 59781,
+
+	/// <summary>Minus Square (Filled)</summary>
+	/// <remarks>Category: Symbols<br/>
+	/// Alias: 3.23.6, symbols, hyphen, line, filled, subtract, filled</remarks>
+	/// <release>3.23.6</release>
+	MinusSquareFilled = 59782,
 
 	/// <summary>Minus Square</summary>
 	/// <remarks>Category: Symbols<br/>
@@ -4280,6 +4400,12 @@ public enum CalciteIcon : ushort
 	/// <release>3.28.0</release>
 	PasteWithoutAttribute = 59866,
 
+	/// <summary>Pause (Filled)</summary>
+	/// <remarks>Category: Media<br/>
+	/// Alias: 1.5.0, media, filled</remarks>
+	/// <release>1.5</release>
+	PauseFilled = 59867,
+
 	/// <summary>Pause</summary>
 	/// <remarks>Category: Media<br/>
 	/// Alias: 1.5.0, media</remarks>
@@ -4394,6 +4520,12 @@ public enum CalciteIcon : ushort
 	/// <release>1.5</release>
 	PinPlus = 59886,
 
+	/// <summary>Pin Tear (Filled)</summary>
+	/// <remarks>Category: Generic<br/>
+	/// Alias: 3.16.1, generic, location, map pin, map marker, destination, dropped pin, drop pin, filled</remarks>
+	/// <release>3.16.1</release>
+	PinTearFilled = 59887,
+
 	/// <summary>Pin Tear</summary>
 	/// <remarks>Category: Generic<br/>
 	/// Alias: 3.16.1, generic, location, map pin, map marker, destination, dropped pin, drop pin</remarks>
@@ -4417,6 +4549,12 @@ public enum CalciteIcon : ushort
 	/// Alias: 3.0.0, blueprint, layout, measurements, perimeter, width, height, boundary, interior, scale</remarks>
 	/// <release>3.0.0</release>
 	Plans = 59891,
+
+	/// <summary>Play (Filled)</summary>
+	/// <remarks>Category: Media<br/>
+	/// Alias: 1.5.0, media, run, test, filled</remarks>
+	/// <release>1.5</release>
+	PlayFilled = 59892,
 
 	/// <summary>Play</summary>
 	/// <remarks>Category: Media<br/>
@@ -4610,6 +4748,12 @@ public enum CalciteIcon : ushort
 	/// <release>3.25.8</release>
 	Query = 59924,
 
+	/// <summary>Question (Filled)</summary>
+	/// <remarks>Category: Symbols<br/>
+	/// Alias: 1.5.0, symbols, faq, unknown, help, hint, filled</remarks>
+	/// <release>1.5</release>
+	QuestionFilled = 59925,
+
 	/// <summary>Question</summary>
 	/// <remarks>Category: Symbols<br/>
 	/// Alias: 1.5.0, symbols, faq, unknown, help, hint</remarks>
@@ -4627,6 +4771,9 @@ public enum CalciteIcon : ushort
 	/// Alias: 3.3.0, quotation marks, reference</remarks>
 	/// <release>3.3.0</release>
 	Quote = 59928,
+
+	/// <summary>Radial Tree Link Chart Yayout</summary>
+	RadialTreeLinkChartYayout = 59929,
 
 	/// <summary>Rain</summary>
 	/// <remarks>Category: Weather<br/>
@@ -4825,6 +4972,12 @@ public enum CalciteIcon : ushort
 	/// Alias: gis, 3.17.1, geoai, train</remarks>
 	/// <release>3.17.1</release>
 	Retrain = 59962,
+
+	/// <summary>Reverse (Filled)</summary>
+	/// <remarks>Category: Media<br/>
+	/// Alias: 1.5.0, media, filled</remarks>
+	/// <release>1.5</release>
+	ReverseFilled = 59963,
 
 	/// <summary>Reverse</summary>
 	/// <remarks>Category: Media<br/>
@@ -5564,6 +5717,12 @@ public enum CalciteIcon : ushort
 	/// <release>3.25.2</release>
 	SplitUnits = 60086,
 
+	/// <summary>Square (Filled)</summary>
+	/// <remarks>Category: Generic<br/>
+	/// Alias: 1.5.0, generic, shapes, box, container, filled</remarks>
+	/// <release>1.5</release>
+	SquareFilled = 60087,
+
 	/// <summary>Square</summary>
 	/// <remarks>Category: Generic<br/>
 	/// Alias: 1.5.0, generic, shapes, box, container</remarks>
@@ -5606,6 +5765,12 @@ public enum CalciteIcon : ushort
 	/// <release>3.22.1</release>
 	StairsUp = 60094,
 
+	/// <summary>Star (Filled)</summary>
+	/// <remarks>Category: Symbols<br/>
+	/// Alias: 3.3.0, symbols, favorite, rate, rating, filled</remarks>
+	/// <release>3.3.0</release>
+	StarFilled = 60095,
+
 	/// <summary>Star</summary>
 	/// <remarks>Category: Symbols<br/>
 	/// Alias: 3.3.0, symbols, favorite, rate, rating</remarks>
@@ -5623,6 +5788,12 @@ public enum CalciteIcon : ushort
 	/// Alias: 3.25.2, symbols, online model builder, stopping, slow, stopped, hold</remarks>
 	/// <release>3.25.2</release>
 	Stop = 60098,
+
+	/// <summary>Stop Square (Filled)</summary>
+	/// <remarks>Category: Media<br/>
+	/// Alias: 3.24.1, media, cube, stop, halt, end, finish, filled</remarks>
+	/// <release>3.24.1</release>
+	StopSquareFilled = 60099,
 
 	/// <summary>Stop Square</summary>
 	/// <remarks>Category: Media<br/>
@@ -5990,6 +6161,12 @@ public enum CalciteIcon : ushort
 	/// <release>3.29.4</release>
 	TracePathComplete = 60160,
 
+	/// <summary>Transcript (Filled)</summary>
+	/// <remarks>Category: Media<br/>
+	/// Alias: 3.29.3, media, captions, text, video, display, speech, filled</remarks>
+	/// <release>3.29.3</release>
+	TranscriptFilled = 60161,
+
 	/// <summary>Transcript</summary>
 	/// <remarks>Category: Media<br/>
 	/// Alias: 3.29.3, media, captions, text, video, display, speech</remarks>
@@ -6356,6 +6533,9 @@ public enum CalciteIcon : ushort
 	/// <release>1.5</release>
 	Web = 60222,
 
+	/// <summary>Web Adaptor</summary>
+	WebAdaptor = 60223,
+
 	/// <summary>Webhook</summary>
 	/// <remarks>Category: Symbols<br/>
 	/// Alias: 3.14.0, symbols, web hook, event, information, manage, create, http request, payload, application, push</remarks>
@@ -6428,11 +6608,23 @@ public enum CalciteIcon : ushort
 	/// <release>3.1.0</release>
 	XBar = 60235,
 
+	/// <summary>X Circle (Filled)</summary>
+	/// <remarks>Category: Symbols<br/>
+	/// Alias: 3.8.1, symbols, delete, remove, close, filled</remarks>
+	/// <release>3.8.1</release>
+	XCircleFilled = 60236,
+
 	/// <summary>X Circle</summary>
 	/// <remarks>Category: Symbols<br/>
 	/// Alias: 3.8.1, symbols, delete, remove, close</remarks>
 	/// <release>3.8.1</release>
 	XCircle = 60237,
+
+	/// <summary>X Octagon (Filled)</summary>
+	/// <remarks>Category: Symbols<br/>
+	/// Alias: 3.11.0, x octagon, invalid, error, broken, critical, denied, restricted, filled</remarks>
+	/// <release>3.11.0</release>
+	XOctagonFilled = 60238,
 
 	/// <summary>X Octagon</summary>
 	/// <remarks>Category: Symbols<br/>

--- a/GeneratedResources/Maui/CalciteIcon.cs
+++ b/GeneratedResources/Maui/CalciteIcon.cs
@@ -4772,9 +4772,6 @@ public enum CalciteIcon : ushort
 	/// <release>3.3.0</release>
 	Quote = 59928,
 
-	/// <summary>Radial Tree Link Chart Yayout</summary>
-	RadialTreeLinkChartYayout = 59929,
-
 	/// <summary>Rain</summary>
 	/// <remarks>Category: Weather<br/>
 	/// Alias: 3.17.6, generic, clouds, weather, sky, forecast, temperature, environment, nature, precipitation, wind, stormy, clouds</remarks>

--- a/GeneratedResources/Maui/IconHelpers.cs
+++ b/GeneratedResources/Maui/IconHelpers.cs
@@ -1,4 +1,4 @@
-// COPYRIGHT © 2025 Esri
+// COPYRIGHT ï¿½ 2025 Esri
 // All rights reserved under the copyright laws of the United States and applicable international laws, treaties, and conventions.
 // This material is licensed for use under the Esri Master License Agreement (MLA), and is bound by the terms of that agreement.
 // You may redistribute and use this code without modification, provided you adhere to the terms of the MLA and include this copyright notice.
@@ -48,6 +48,7 @@ internal static class IconHelpers
 			case CalciteIcon.AddText: return "AddText";
 			case CalciteIcon.AddToModel: return "AddToModel";
 			case CalciteIcon.AddressBook: return "AddressBook";
+			case CalciteIcon.AlertOffCircleFilled: return "AlertOffCircleFilled";
 			case CalciteIcon.AllServers: return "AllServers";
 			case CalciteIcon.Altitude: return "Altitude";
 			case CalciteIcon.Analysis: return "Analysis";
@@ -102,7 +103,9 @@ internal static class IconHelpers
 			case CalciteIcon.Beaker: return "Beaker";
 			case CalciteIcon.BearLeft: return "BearLeft";
 			case CalciteIcon.BearRight: return "BearRight";
+			case CalciteIcon.BeginningFilled: return "BeginningFilled";
 			case CalciteIcon.Beginning: return "Beginning";
+			case CalciteIcon.BellFilled: return "BellFilled";
 			case CalciteIcon.Bell: return "Bell";
 			case CalciteIcon.BellOff: return "BellOff";
 			case CalciteIcon.Beta: return "Beta";
@@ -161,10 +164,12 @@ internal static class IconHelpers
 			case CalciteIcon.ChartGear: return "ChartGear";
 			case CalciteIcon.ChartMagnifyingGlass: return "ChartMagnifyingGlass";
 			case CalciteIcon.Check: return "Check";
+			case CalciteIcon.CheckCircleFilled: return "CheckCircleFilled";
 			case CalciteIcon.CheckCircle: return "CheckCircle";
 			case CalciteIcon.CheckExtent: return "CheckExtent";
 			case CalciteIcon.CheckLayer: return "CheckLayer";
 			case CalciteIcon.CheckShield: return "CheckShield";
+			case CalciteIcon.CheckSquareFilled: return "CheckSquareFilled";
 			case CalciteIcon.CheckSquare: return "CheckSquare";
 			case CalciteIcon.ChevronDown: return "ChevronDown";
 			case CalciteIcon.ChevronDownLeft: return "ChevronDownLeft";
@@ -181,12 +186,15 @@ internal static class IconHelpers
 			case CalciteIcon.ChevronsRight: return "ChevronsRight";
 			case CalciteIcon.ChevronsUp: return "ChevronsUp";
 			case CalciteIcon.ChordDiagram: return "ChordDiagram";
+			case CalciteIcon.CircleFilled: return "CircleFilled";
 			case CalciteIcon.Circle: return "Circle";
 			case CalciteIcon.CircleDisallowed: return "CircleDisallowed";
 			case CalciteIcon.CircleInsetLarge: return "CircleInsetLarge";
 			case CalciteIcon.CircleInsetMedium: return "CircleInsetMedium";
 			case CalciteIcon.CircleInsetSmall: return "CircleInsetSmall";
+			case CalciteIcon.CirclePauseFilled: return "CirclePauseFilled";
 			case CalciteIcon.CirclePause: return "CirclePause";
+			case CalciteIcon.CircleStopFilled: return "CircleStopFilled";
 			case CalciteIcon.CircleStop: return "CircleStop";
 			case CalciteIcon.ClassifyObjects: return "ClassifyObjects";
 			case CalciteIcon.ClearSelection: return "ClearSelection";
@@ -196,6 +204,7 @@ internal static class IconHelpers
 			case CalciteIcon.ClockDown: return "ClockDown";
 			case CalciteIcon.ClockForward: return "ClockForward";
 			case CalciteIcon.ClockUp: return "ClockUp";
+			case CalciteIcon.ClosedCaptionFilled: return "ClosedCaptionFilled";
 			case CalciteIcon.ClosedCaption: return "ClosedCaption";
 			case CalciteIcon.Cloud: return "Cloud";
 			case CalciteIcon.CloudData: return "CloudData";
@@ -322,6 +331,7 @@ internal static class IconHelpers
 			case CalciteIcon.EmbeddedLiveContent: return "EmbeddedLiveContent";
 			case CalciteIcon.EmployeeId: return "EmployeeId";
 			case CalciteIcon.EnableDisableFeatureSelection: return "EnableDisableFeatureSelection";
+			case CalciteIcon.EndFilled: return "EndFilled";
 			case CalciteIcon.End: return "End";
 			case CalciteIcon.Envelope: return "Envelope";
 			case CalciteIcon.Erase: return "Erase";
@@ -329,7 +339,9 @@ internal static class IconHelpers
 			case CalciteIcon.EscalatorDown: return "EscalatorDown";
 			case CalciteIcon.EscalatorUp: return "EscalatorUp";
 			case CalciteIcon.Event: return "Event";
+			case CalciteIcon.ExclamationMarkCircleFilled: return "ExclamationMarkCircleFilled";
 			case CalciteIcon.ExclamationMarkCircle: return "ExclamationMarkCircle";
+			case CalciteIcon.ExclamationMarkTriangleFilled: return "ExclamationMarkTriangleFilled";
 			case CalciteIcon.ExclamationMarkTriangle: return "ExclamationMarkTriangle";
 			case CalciteIcon.ExclamationPointFilled: return "ExclamationPointFilled";
 			case CalciteIcon.ExclamationPoint: return "ExclamationPoint";
@@ -377,6 +389,7 @@ internal static class IconHelpers
 			case CalciteIcon.Filter: return "Filter";
 			case CalciteIcon.FilterExpand: return "FilterExpand";
 			case CalciteIcon.Fingerprint: return "Fingerprint";
+			case CalciteIcon.FlagFilled: return "FlagFilled";
 			case CalciteIcon.Flag: return "Flag";
 			case CalciteIcon.FlagSlash: return "FlagSlash";
 			case CalciteIcon.Flash: return "Flash";
@@ -410,6 +423,7 @@ internal static class IconHelpers
 			case CalciteIcon.FormField: return "FormField";
 			case CalciteIcon.FormFieldMultiline: return "FormFieldMultiline";
 			case CalciteIcon.FormFieldOff: return "FormFieldOff";
+			case CalciteIcon.ForwardFilled: return "ForwardFilled";
 			case CalciteIcon.Forward: return "Forward";
 			case CalciteIcon.FrameExport: return "FrameExport";
 			case CalciteIcon.Freehand: return "Freehand";
@@ -431,6 +445,7 @@ internal static class IconHelpers
 			case CalciteIcon.GisServer: return "GisServer";
 			case CalciteIcon.Globe: return "Globe";
 			case CalciteIcon.GpsOff: return "GpsOff";
+			case CalciteIcon.GpsOnFilled: return "GpsOnFilled";
 			case CalciteIcon.GpsOn: return "GpsOn";
 			case CalciteIcon.GraphAxis: return "GraphAxis";
 			case CalciteIcon.GraphBar100Stacked: return "GraphBar100Stacked";
@@ -464,6 +479,7 @@ internal static class IconHelpers
 			case CalciteIcon.HeadingLayout: return "HeadingLayout";
 			case CalciteIcon.HeadingRtl: return "HeadingRtl";
 			case CalciteIcon.Headset: return "Headset";
+			case CalciteIcon.HeartFilled: return "HeartFilled";
 			case CalciteIcon.Heart: return "Heart";
 			case CalciteIcon.HeatChart: return "HeatChart";
 			case CalciteIcon.HeavyRain: return "HeavyRain";
@@ -504,6 +520,7 @@ internal static class IconHelpers
 			case CalciteIcon.IncreaseLinkChartSymbolSize: return "IncreaseLinkChartSymbolSize";
 			case CalciteIcon.Indicator: return "Indicator";
 			case CalciteIcon.Infographic: return "Infographic";
+			case CalciteIcon.InformationFilled: return "InformationFilled";
 			case CalciteIcon.Information: return "Information";
 			case CalciteIcon.InformationLetter: return "InformationLetter";
 			case CalciteIcon.Initiative: return "Initiative";
@@ -601,6 +618,7 @@ internal static class IconHelpers
 			case CalciteIcon.LocationSharing: return "LocationSharing";
 			case CalciteIcon.LocationSharingOff: return "LocationSharingOff";
 			case CalciteIcon.Locator: return "Locator";
+			case CalciteIcon.LockFilled: return "LockFilled";
 			case CalciteIcon.Lock: return "Lock";
 			case CalciteIcon.LtrElementsAlign: return "LtrElementsAlign";
 			case CalciteIcon.LtrParagraphAlign: return "LtrParagraphAlign";
@@ -642,7 +660,9 @@ internal static class IconHelpers
 			case CalciteIcon.Minimum: return "Minimum";
 			case CalciteIcon.MinimumGraph: return "MinimumGraph";
 			case CalciteIcon.Minus: return "Minus";
+			case CalciteIcon.MinusCircleFilled: return "MinusCircleFilled";
 			case CalciteIcon.MinusCircle: return "MinusCircle";
+			case CalciteIcon.MinusSquareFilled: return "MinusSquareFilled";
 			case CalciteIcon.MinusSquare: return "MinusSquare";
 			case CalciteIcon.MiscellaneousCollection: return "MiscellaneousCollection";
 			case CalciteIcon.MissionServer: return "MissionServer";
@@ -727,6 +747,7 @@ internal static class IconHelpers
 			case CalciteIcon.Paste: return "Paste";
 			case CalciteIcon.PasteWithAttribute: return "PasteWithAttribute";
 			case CalciteIcon.PasteWithoutAttribute: return "PasteWithoutAttribute";
+			case CalciteIcon.PauseFilled: return "PauseFilled";
 			case CalciteIcon.Pause: return "Pause";
 			case CalciteIcon.Pen: return "Pen";
 			case CalciteIcon.PenMark: return "PenMark";
@@ -746,10 +767,12 @@ internal static class IconHelpers
 			case CalciteIcon.PieChart: return "PieChart";
 			case CalciteIcon.Pin: return "Pin";
 			case CalciteIcon.PinPlus: return "PinPlus";
+			case CalciteIcon.PinTearFilled: return "PinTearFilled";
 			case CalciteIcon.PinTear: return "PinTear";
 			case CalciteIcon.Pins: return "Pins";
 			case CalciteIcon.Plane: return "Plane";
 			case CalciteIcon.Plans: return "Plans";
+			case CalciteIcon.PlayFilled: return "PlayFilled";
 			case CalciteIcon.Play: return "Play";
 			case CalciteIcon.Plus: return "Plus";
 			case CalciteIcon.PlusCircle: return "PlusCircle";
@@ -782,9 +805,11 @@ internal static class IconHelpers
 			case CalciteIcon.QrCode: return "QrCode";
 			case CalciteIcon.QtCode: return "QtCode";
 			case CalciteIcon.Query: return "Query";
+			case CalciteIcon.QuestionFilled: return "QuestionFilled";
 			case CalciteIcon.Question: return "Question";
 			case CalciteIcon.QuestionMark: return "QuestionMark";
 			case CalciteIcon.Quote: return "Quote";
+			case CalciteIcon.RadialTreeLinkChartYayout: return "RadialTreeLinkChartYayout";
 			case CalciteIcon.Rain: return "Rain";
 			case CalciteIcon.RainSnow: return "RainSnow";
 			case CalciteIcon.RainThunder: return "RainThunder";
@@ -818,6 +843,7 @@ internal static class IconHelpers
 			case CalciteIcon.ReshapeTool: return "ReshapeTool";
 			case CalciteIcon.ResizeArea: return "ResizeArea";
 			case CalciteIcon.Retrain: return "Retrain";
+			case CalciteIcon.ReverseFilled: return "ReverseFilled";
 			case CalciteIcon.Reverse: return "Reverse";
 			case CalciteIcon.Rfid: return "Rfid";
 			case CalciteIcon.Rhombus: return "Rhombus";
@@ -941,6 +967,7 @@ internal static class IconHelpers
 			case CalciteIcon.SplitFeatures: return "SplitFeatures";
 			case CalciteIcon.SplitGeometry: return "SplitGeometry";
 			case CalciteIcon.SplitUnits: return "SplitUnits";
+			case CalciteIcon.SquareFilled: return "SquareFilled";
 			case CalciteIcon.Square: return "Square";
 			case CalciteIcon.SquareInsetLarge: return "SquareInsetLarge";
 			case CalciteIcon.SquareInsetMedium: return "SquareInsetMedium";
@@ -948,9 +975,11 @@ internal static class IconHelpers
 			case CalciteIcon.Stairs: return "Stairs";
 			case CalciteIcon.StairsDown: return "StairsDown";
 			case CalciteIcon.StairsUp: return "StairsUp";
+			case CalciteIcon.StarFilled: return "StarFilled";
 			case CalciteIcon.Star: return "Star";
 			case CalciteIcon.StarCircle: return "StarCircle";
 			case CalciteIcon.Stop: return "Stop";
+			case CalciteIcon.StopSquareFilled: return "StopSquareFilled";
 			case CalciteIcon.StopSquare: return "StopSquare";
 			case CalciteIcon.Storage: return "Storage";
 			case CalciteIcon.StoredAsNewQuery: return "StoredAsNewQuery";
@@ -1012,6 +1041,7 @@ internal static class IconHelpers
 			case CalciteIcon.Trace: return "Trace";
 			case CalciteIcon.TracePath: return "TracePath";
 			case CalciteIcon.TracePathComplete: return "TracePathComplete";
+			case CalciteIcon.TranscriptFilled: return "TranscriptFilled";
 			case CalciteIcon.Transcript: return "Transcript";
 			case CalciteIcon.TransverseHexagon: return "TransverseHexagon";
 			case CalciteIcon.Trash: return "Trash";
@@ -1073,6 +1103,7 @@ internal static class IconHelpers
 			case CalciteIcon.WalkingDistance: return "WalkingDistance";
 			case CalciteIcon.WalkingTime: return "WalkingTime";
 			case CalciteIcon.Web: return "Web";
+			case CalciteIcon.WebAdaptor: return "WebAdaptor";
 			case CalciteIcon.Webhook: return "Webhook";
 			case CalciteIcon.Wheelchair: return "Wheelchair";
 			case CalciteIcon.WidgetsGroup: return "WidgetsGroup";
@@ -1085,7 +1116,9 @@ internal static class IconHelpers
 			case CalciteIcon.X: return "X";
 			case CalciteIcon.XAxisGuide: return "XAxisGuide";
 			case CalciteIcon.XBar: return "XBar";
+			case CalciteIcon.XCircleFilled: return "XCircleFilled";
 			case CalciteIcon.XCircle: return "XCircle";
+			case CalciteIcon.XOctagonFilled: return "XOctagonFilled";
 			case CalciteIcon.XOctagon: return "XOctagon";
 			case CalciteIcon.YAxisGuide: return "YAxisGuide";
 			case CalciteIcon.ZoomInFixed: return "ZoomInFixed";

--- a/GeneratedResources/Maui/IconHelpers.cs
+++ b/GeneratedResources/Maui/IconHelpers.cs
@@ -809,7 +809,6 @@ internal static class IconHelpers
 			case CalciteIcon.Question: return "Question";
 			case CalciteIcon.QuestionMark: return "QuestionMark";
 			case CalciteIcon.Quote: return "Quote";
-			case CalciteIcon.RadialTreeLinkChartYayout: return "RadialTreeLinkChartYayout";
 			case CalciteIcon.Rain: return "Rain";
 			case CalciteIcon.RainSnow: return "RainSnow";
 			case CalciteIcon.RainThunder: return "RainThunder";

--- a/GeneratedResources/Maui/Icons/Glyphs.xaml
+++ b/GeneratedResources/Maui/Icons/Glyphs.xaml
@@ -852,7 +852,6 @@
     <x:String x:Key="CalciteUIIcons_Glyph_QuestionMark">&#xea17;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_Quote">&#xea18;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_RadialTreeLinkChartLayout">&#xeb65;</x:String> 
-    <x:String x:Key="CalciteUIIcons_Glyph_RadialTreeLinkChartYayout">&#xea19;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_Rain">&#xea1a;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_RainSnow">&#xea1b;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_RainThunder">&#xea1c;</x:String> 

--- a/GeneratedResources/Maui/Icons/Glyphs.xaml
+++ b/GeneratedResources/Maui/Icons/Glyphs.xaml
@@ -31,6 +31,7 @@
     <x:String x:Key="CalciteUIIcons_Glyph_AddText">&#xe71d;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_AddToModel">&#xe71e;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_AddressBook">&#xe71f;</x:String> 
+    <x:String x:Key="CalciteUIIcons_Glyph_AlertOffCircleFilled">&#xe720;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_AllServers">&#xe721;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_Altitude">&#xe722;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_Analysis">&#xe723;</x:String> 
@@ -88,7 +89,9 @@
     <x:String x:Key="CalciteUIIcons_Glyph_BearLeft">&#xe755;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_BearRight">&#xe756;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_Beginning">&#xe758;</x:String> 
+    <x:String x:Key="CalciteUIIcons_Glyph_BeginningFilled">&#xe757;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_Bell">&#xe75a;</x:String> 
+    <x:String x:Key="CalciteUIIcons_Glyph_BellFilled">&#xe759;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_BellOff">&#xe75b;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_Beta">&#xe75c;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_Biking">&#xe75d;</x:String> 
@@ -153,10 +156,12 @@
     <x:String x:Key="CalciteUIIcons_Glyph_ChartMagnifyingGlass">&#xe792;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_Check">&#xe793;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_CheckCircle">&#xe795;</x:String> 
+    <x:String x:Key="CalciteUIIcons_Glyph_CheckCircleFilled">&#xe794;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_CheckExtent">&#xe796;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_CheckLayer">&#xe797;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_CheckShield">&#xe798;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_CheckSquare">&#xe79a;</x:String> 
+    <x:String x:Key="CalciteUIIcons_Glyph_CheckSquareFilled">&#xe799;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_ChevronDown">&#xe79b;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_ChevronDownLeft">&#xe79c;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_ChevronDownRight">&#xe79d;</x:String> 
@@ -173,13 +178,16 @@
     <x:String x:Key="CalciteUIIcons_Glyph_ChevronsUp">&#xe7a8;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_ChordDiagram">&#xe7a9;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_Circle">&#xe7ab;</x:String> 
+    <x:String x:Key="CalciteUIIcons_Glyph_CircleFilled">&#xe7aa;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_CircleAreaHashFilled">&#xeb74;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_CircleDisallowed">&#xe7ac;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_CircleInsetLarge">&#xe7ad;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_CircleInsetMedium">&#xe7ae;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_CircleInsetSmall">&#xe7af;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_CirclePause">&#xe7b1;</x:String> 
+    <x:String x:Key="CalciteUIIcons_Glyph_CirclePauseFilled">&#xe7b0;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_CircleStop">&#xe7b3;</x:String> 
+    <x:String x:Key="CalciteUIIcons_Glyph_CircleStopFilled">&#xe7b2;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_ClassifyObjects">&#xe7b4;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_ClearSelection">&#xe7b5;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_Clipboard">&#xe7b6;</x:String> 
@@ -189,6 +197,7 @@
     <x:String x:Key="CalciteUIIcons_Glyph_ClockForward">&#xe7ba;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_ClockUp">&#xe7bb;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_ClosedCaption">&#xe7bd;</x:String> 
+    <x:String x:Key="CalciteUIIcons_Glyph_ClosedCaptionFilled">&#xe7bc;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_Cloud">&#xe7be;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_CloudData">&#xe7bf;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_CloudServer">&#xe7c0;</x:String> 
@@ -329,6 +338,7 @@
     <x:String x:Key="CalciteUIIcons_Glyph_EmployeeId">&#xe839;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_EnableDisableFeatureSelection">&#xe83a;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_End">&#xe83c;</x:String> 
+    <x:String x:Key="CalciteUIIcons_Glyph_EndFilled">&#xe83b;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_Envelope">&#xe83d;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_Erase">&#xe83e;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_Escalator">&#xe83f;</x:String> 
@@ -336,7 +346,9 @@
     <x:String x:Key="CalciteUIIcons_Glyph_EscalatorUp">&#xe841;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_Event">&#xe842;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_ExclamationMarkCircle">&#xe844;</x:String> 
+    <x:String x:Key="CalciteUIIcons_Glyph_ExclamationMarkCircleFilled">&#xe843;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_ExclamationMarkTriangle">&#xe846;</x:String> 
+    <x:String x:Key="CalciteUIIcons_Glyph_ExclamationMarkTriangleFilled">&#xe845;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_ExclamationPoint">&#xe848;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_ExclamationPointFilled">&#xe847;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_ExitHighwayLeft">&#xe849;</x:String> 
@@ -386,6 +398,7 @@
     <x:String x:Key="CalciteUIIcons_Glyph_FindAddPath">&#xf118;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_Fingerprint">&#xe874;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_Flag">&#xe876;</x:String> 
+    <x:String x:Key="CalciteUIIcons_Glyph_FlagFilled">&#xe875;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_FlagSlash">&#xe877;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_Flash">&#xe878;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_Flip">&#xe879;</x:String> 
@@ -419,6 +432,7 @@
     <x:String x:Key="CalciteUIIcons_Glyph_FormFieldMultiline">&#xe895;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_FormFieldOff">&#xe896;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_Forward">&#xe898;</x:String> 
+    <x:String x:Key="CalciteUIIcons_Glyph_ForwardFilled">&#xe897;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_FourTimes">&#xe708;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_FrameExport">&#xe899;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_Freehand">&#xe89a;</x:String> 
@@ -442,6 +456,7 @@
     <x:String x:Key="CalciteUIIcons_Glyph_GovernmentBuilding">&#xeb76;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_GpsOff">&#xe8ac;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_GpsOn">&#xe8ae;</x:String> 
+    <x:String x:Key="CalciteUIIcons_Glyph_GpsOnFilled">&#xe8ad;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_GraphAxis">&#xe8af;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_GraphBar">&#xe8b1;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_GraphBar100Stacked">&#xe8b0;</x:String> 
@@ -477,6 +492,7 @@
     <x:String x:Key="CalciteUIIcons_Glyph_HeadingRtl">&#xe8cd;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_Headset">&#xe8ce;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_Heart">&#xe8d0;</x:String> 
+    <x:String x:Key="CalciteUIIcons_Glyph_HeartFilled">&#xe8cf;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_HeatChart">&#xe8d1;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_HeavyRain">&#xe8d2;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_HeavySnow">&#xe8d3;</x:String> 
@@ -520,6 +536,7 @@
     <x:String x:Key="CalciteUIIcons_Glyph_Indicator">&#xe8f6;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_Infographic">&#xe8f7;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_Information">&#xe8f9;</x:String> 
+    <x:String x:Key="CalciteUIIcons_Glyph_InformationFilled">&#xe8f8;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_InformationLetter">&#xe8fa;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_Initiative">&#xe8fb;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_InitiativeTemplate">&#xeb5f;</x:String> 
@@ -629,6 +646,7 @@
     <x:String x:Key="CalciteUIIcons_Glyph_LocationSharingOff">&#xe958;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_Locator">&#xe959;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_Lock">&#xe95b;</x:String> 
+    <x:String x:Key="CalciteUIIcons_Glyph_LockFilled">&#xe95a;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_LtrElementsAlign">&#xe95c;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_LtrParagraphAlign">&#xe95d;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_MagnifyingGlass">&#xe95e;</x:String> 
@@ -671,7 +689,9 @@
     <x:String x:Key="CalciteUIIcons_Glyph_MinimumGraph">&#xe982;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_Minus">&#xe983;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_MinusCircle">&#xe985;</x:String> 
+    <x:String x:Key="CalciteUIIcons_Glyph_MinusCircleFilled">&#xe984;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_MinusSquare">&#xe987;</x:String> 
+    <x:String x:Key="CalciteUIIcons_Glyph_MinusSquareFilled">&#xe986;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_MiscellaneousCollection">&#xe988;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_MissionServer">&#xe989;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_Mobile">&#xe98a;</x:String> 
@@ -766,6 +786,7 @@
     <x:String x:Key="CalciteUIIcons_Glyph_PasteWithAttribute">&#xe9d9;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_PasteWithoutAttribute">&#xe9da;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_Pause">&#xe9dc;</x:String> 
+    <x:String x:Key="CalciteUIIcons_Glyph_PauseFilled">&#xe9db;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_Pen">&#xe9dd;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_PenMark">&#xe9de;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_PenMarkPlus">&#xe9df;</x:String> 
@@ -787,10 +808,12 @@
     <x:String x:Key="CalciteUIIcons_Glyph_Pin">&#xe9ed;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_PinPlus">&#xe9ee;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_PinTear">&#xe9f0;</x:String> 
+    <x:String x:Key="CalciteUIIcons_Glyph_PinTearFilled">&#xe9ef;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_Pins">&#xe9f1;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_Plane">&#xe9f2;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_Plans">&#xe9f3;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_Play">&#xe9f5;</x:String> 
+    <x:String x:Key="CalciteUIIcons_Glyph_PlayFilled">&#xe9f4;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_PlugConnection">&#xf109;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_Plus">&#xe9f6;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_PlusCircle">&#xe9f7;</x:String> 
@@ -825,9 +848,11 @@
     <x:String x:Key="CalciteUIIcons_Glyph_QtCode">&#xea13;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_Query">&#xea14;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_Question">&#xea16;</x:String> 
+    <x:String x:Key="CalciteUIIcons_Glyph_QuestionFilled">&#xea15;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_QuestionMark">&#xea17;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_Quote">&#xea18;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_RadialTreeLinkChartLayout">&#xeb65;</x:String> 
+    <x:String x:Key="CalciteUIIcons_Glyph_RadialTreeLinkChartYayout">&#xea19;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_Rain">&#xea1a;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_RainSnow">&#xea1b;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_RainThunder">&#xea1c;</x:String> 
@@ -863,6 +888,7 @@
     <x:String x:Key="CalciteUIIcons_Glyph_ResizeArea">&#xea39;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_Retrain">&#xea3a;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_Reverse">&#xea3c;</x:String> 
+    <x:String x:Key="CalciteUIIcons_Glyph_ReverseFilled">&#xea3b;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_Rfid">&#xea3d;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_Rhombus">&#xea3e;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_Ribbon">&#xea3f;</x:String> 
@@ -997,6 +1023,7 @@
     <x:String x:Key="CalciteUIIcons_Glyph_SplitGeometry">&#xeab5;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_SplitUnits">&#xeab6;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_Square">&#xeab8;</x:String> 
+    <x:String x:Key="CalciteUIIcons_Glyph_SquareFilled">&#xeab7;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_SquareBracketsX">&#xeb69;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_SquareHashFilled">&#xeb80;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_SquareHashFilledArea">&#xeb7f;</x:String> 
@@ -1007,9 +1034,11 @@
     <x:String x:Key="CalciteUIIcons_Glyph_StairsDown">&#xeabd;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_StairsUp">&#xeabe;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_Star">&#xeac0;</x:String> 
+    <x:String x:Key="CalciteUIIcons_Glyph_StarFilled">&#xeabf;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_StarCircle">&#xeac1;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_Stop">&#xeac2;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_StopSquare">&#xeac4;</x:String> 
+    <x:String x:Key="CalciteUIIcons_Glyph_StopSquareFilled">&#xeac3;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_Storage">&#xeac5;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_StoredAsNewQuery">&#xeac6;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_StoredQuery">&#xeac7;</x:String> 
@@ -1071,6 +1100,7 @@
     <x:String x:Key="CalciteUIIcons_Glyph_TracePath">&#xeaff;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_TracePathComplete">&#xeb00;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_Transcript">&#xeb02;</x:String> 
+    <x:String x:Key="CalciteUIIcons_Glyph_TranscriptFilled">&#xeb01;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_TransverseHexagon">&#xeb03;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_Trash">&#xeb04;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_Tree">&#xeb81;</x:String> 
@@ -1139,6 +1169,7 @@
     <x:String x:Key="CalciteUIIcons_Glyph_WaterDrop">&#xeb82;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_Web">&#xeb3e;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_WebAdapter">&#xeb6b;</x:String> 
+    <x:String x:Key="CalciteUIIcons_Glyph_WebAdaptor">&#xeb3f;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_Webhook">&#xeb40;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_Wheelchair">&#xeb41;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_WhiteCursorSelection">&#xeb83;</x:String> 
@@ -1154,7 +1185,9 @@
     <x:String x:Key="CalciteUIIcons_Glyph_XAxisGuide">&#xeb4a;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_XBar">&#xeb4b;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_XCircle">&#xeb4d;</x:String> 
+    <x:String x:Key="CalciteUIIcons_Glyph_XCircleFilled">&#xeb4c;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_XOctagon">&#xeb4f;</x:String> 
+    <x:String x:Key="CalciteUIIcons_Glyph_XOctagonFilled">&#xeb4e;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_YAxisGuide">&#xeb50;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_ZoningParameter">&#xeb6c;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_ZoomInFixed">&#xeb51;</x:String> 

--- a/GeneratedResources/WPF/CalciteIcon.cs
+++ b/GeneratedResources/WPF/CalciteIcon.cs
@@ -206,6 +206,12 @@ public enum CalciteIcon : ushort
 	/// <release>3.0.0</release>
 	AddressBook = 59167,
 
+	/// <summary>Alert Off Circle (Filled)</summary>
+	/// <remarks>Category: Objects<br/>
+	/// Alias: 3.24.2, objects, bell, no notifications, silent, vibrate, unsubscribe, turn off, no alarm, no announcements, filled</remarks>
+	/// <release>3.24.2</release>
+	AlertOffCircleFilled = 59168,
+
 	/// <summary>All Servers</summary>
 	/// <remarks>Category: GIS<br/>
 	/// Alias: 3.20.7, gis, connections, connected, networks</remarks>
@@ -530,11 +536,23 @@ public enum CalciteIcon : ushort
 	/// <release>1.5</release>
 	BearRight = 59222,
 
+	/// <summary>Beginning (Filled)</summary>
+	/// <remarks>Category: Media<br/>
+	/// Alias: 1.5.0, start, first, media, filled</remarks>
+	/// <release>1.5</release>
+	BeginningFilled = 59223,
+
 	/// <summary>Beginning</summary>
 	/// <remarks>Category: Media<br/>
 	/// Alias: 1.5.0, start, first, media</remarks>
 	/// <release>1.5</release>
 	Beginning = 59224,
+
+	/// <summary>Bell (Filled)</summary>
+	/// <remarks>Category: Objects<br/>
+	/// Alias: 3.14.5, objects, notification, alert, alarm, bell, filled</remarks>
+	/// <release>3.14.5</release>
+	BellFilled = 59225,
 
 	/// <summary>Bell</summary>
 	/// <remarks>Category: Objects<br/>
@@ -884,6 +902,12 @@ public enum CalciteIcon : ushort
 	/// <release>1.5</release>
 	Check = 59283,
 
+	/// <summary>Check Circle (Filled)</summary>
+	/// <remarks>Category: Symbols<br/>
+	/// Alias: 1.5.0, symbols, check, mark, selected, circle, filled</remarks>
+	/// <release>1.5</release>
+	CheckCircleFilled = 59284,
+
 	/// <summary>Check Circle</summary>
 	/// <remarks>Category: Symbols<br/>
 	/// Alias: 1.5.0, symbols, check, mark, selected, circle</remarks>
@@ -907,6 +931,12 @@ public enum CalciteIcon : ushort
 	/// Alias: 3.15.2, objects, safety, insurance, protection, insured, secure, security, anti-virus, cybersecurity, defense, protected, warranty, coverage</remarks>
 	/// <release>3.15.2</release>
 	CheckShield = 59288,
+
+	/// <summary>Check Square (Filled)</summary>
+	/// <remarks>Category: Symbols<br/>
+	/// Alias: 1.5.0, symbols, done, box, select, tick, check mark, toggle, confirm, correct, selected, filled</remarks>
+	/// <release>1.5</release>
+	CheckSquareFilled = 59289,
 
 	/// <summary>Check Square</summary>
 	/// <remarks>Category: Symbols<br/>
@@ -1004,6 +1034,12 @@ public enum CalciteIcon : ushort
 	/// <release>1.5</release>
 	ChordDiagram = 59305,
 
+	/// <summary>Circle (Filled)</summary>
+	/// <remarks>Category: Generic<br/>
+	/// Alias: 1.5.0, generic, radio, shape, empty, button, filled</remarks>
+	/// <release>1.5</release>
+	CircleFilled = 59306,
+
 	/// <summary>Circle</summary>
 	/// <remarks>Category: Generic<br/>
 	/// Alias: 1.5.0, generic, radio, shape, empty, button</remarks>
@@ -1034,11 +1070,23 @@ public enum CalciteIcon : ushort
 	/// <release>3.28.8</release>
 	CircleInsetSmall = 59311,
 
+	/// <summary>Circle Pause (Filled)</summary>
+	/// <remarks>Category: Symbols<br/>
+	/// Alias: 3.23.0, symbols, stop, hold, pausing, waiting, slow, status, filled</remarks>
+	/// <release>3.23.0</release>
+	CirclePauseFilled = 59312,
+
 	/// <summary>Circle Pause</summary>
 	/// <remarks>Category: Symbols<br/>
 	/// Alias: 3.23.0, symbols, stop, hold, pausing, waiting, slow, status</remarks>
 	/// <release>3.23.0</release>
 	CirclePause = 59313,
+
+	/// <summary>Circle Stop (Filled)</summary>
+	/// <remarks>Category: Symbols<br/>
+	/// Alias: 3.24.1, symbols, cube, stop, halt, end, finish, button, filled</remarks>
+	/// <release>3.24.1</release>
+	CircleStopFilled = 59314,
 
 	/// <summary>Circle Stop</summary>
 	/// <remarks>Category: Symbols<br/>
@@ -1093,6 +1141,12 @@ public enum CalciteIcon : ushort
 	/// Alias: 1.5.0, objects, time, date, sort, ascending</remarks>
 	/// <release>1.5</release>
 	ClockUp = 59323,
+
+	/// <summary>Closed Caption (Filled)</summary>
+	/// <remarks>Category: Media<br/>
+	/// Alias: 3.29.3, media, media, audio, video, display, text, information, filled</remarks>
+	/// <release>3.29.3</release>
+	ClosedCaptionFilled = 59324,
 
 	/// <summary>Closed Caption</summary>
 	/// <remarks>Category: Media<br/>
@@ -1850,6 +1904,12 @@ public enum CalciteIcon : ushort
 	/// <release>3.25.2</release>
 	EnableDisableFeatureSelection = 59450,
 
+	/// <summary>End (Filled)</summary>
+	/// <remarks>Category: Media<br/>
+	/// Alias: 1.5.0, media, filled</remarks>
+	/// <release>1.5</release>
+	EndFilled = 59451,
+
 	/// <summary>End</summary>
 	/// <remarks>Category: Media<br/>
 	/// Alias: 1.5.0, media</remarks>
@@ -1892,11 +1952,23 @@ public enum CalciteIcon : ushort
 	/// <release>3.0.0</release>
 	Event = 59458,
 
+	/// <summary>Exclamation Mark Circle (Filled)</summary>
+	/// <remarks>Category: Symbols<br/>
+	/// Alias: 1.5.0, symbols, invalid, error, broken, filled</remarks>
+	/// <release>1.5</release>
+	ExclamationMarkCircleFilled = 59459,
+
 	/// <summary>Exclamation Mark Circle</summary>
 	/// <remarks>Category: Symbols<br/>
 	/// Alias: 1.5.0, symbols, invalid, error, broken</remarks>
 	/// <release>1.5</release>
 	ExclamationMarkCircle = 59460,
+
+	/// <summary>Exclamation Mark Triangle (Filled)</summary>
+	/// <remarks>Category: Symbols<br/>
+	/// Alias: 1.5.0, symbols, warning, alert, filled</remarks>
+	/// <release>1.5</release>
+	ExclamationMarkTriangleFilled = 59461,
 
 	/// <summary>Exclamation Mark Triangle</summary>
 	/// <remarks>Category: Symbols<br/>
@@ -2180,6 +2252,12 @@ public enum CalciteIcon : ushort
 	/// <release>3.17.0</release>
 	Fingerprint = 59508,
 
+	/// <summary>Flag (Filled)</summary>
+	/// <remarks>Category: Objects<br/>
+	/// Alias: 3.29.1, objects, signal, flag, sign, important, warning, alert, caution, filled</remarks>
+	/// <release>3.29.1</release>
+	FlagFilled = 59509,
+
 	/// <summary>Flag</summary>
 	/// <remarks>Category: Objects<br/>
 	/// Alias: 3.29.1, objects, signal, flag, sign, important, warning, alert, caution</remarks>
@@ -2378,6 +2456,12 @@ public enum CalciteIcon : ushort
 	/// <release>3.16.6</release>
 	FormFieldOff = 59542,
 
+	/// <summary>Forward (Filled)</summary>
+	/// <remarks>Category: Media<br/>
+	/// Alias: 1.5.0, media, filled</remarks>
+	/// <release>1.5</release>
+	ForwardFilled = 59543,
+
 	/// <summary>Forward</summary>
 	/// <remarks>Category: Media<br/>
 	/// Alias: 1.5.0, media</remarks>
@@ -2503,6 +2587,12 @@ public enum CalciteIcon : ushort
 	/// Alias: 1.5.0, gis, locate, current location, tracking</remarks>
 	/// <release>1.5</release>
 	GpsOff = 59564,
+
+	/// <summary>Gps On (Filled)</summary>
+	/// <remarks>Category: GIS<br/>
+	/// Alias: 1.5.0, gis, locate, current location, tracking, filled</remarks>
+	/// <release>1.5</release>
+	GpsOnFilled = 59565,
 
 	/// <summary>Gps On</summary>
 	/// <remarks>Category: GIS<br/>
@@ -2701,6 +2791,12 @@ public enum CalciteIcon : ushort
 	/// Alias: 1.5.0, objects, headphones, customer, service, representative, support</remarks>
 	/// <release>1.5</release>
 	Headset = 59598,
+
+	/// <summary>Heart (Filled)</summary>
+	/// <remarks>Category: Generic<br/>
+	/// Alias: 3.19.9, generic, shape, love, favorite, valentine, gift, like, filled</remarks>
+	/// <release>3.19.9</release>
+	HeartFilled = 59599,
 
 	/// <summary>Heart</summary>
 	/// <remarks>Category: Generic<br/>
@@ -2941,6 +3037,12 @@ public enum CalciteIcon : ushort
 	/// Alias: 1.5.0, generic, shapes, visualization</remarks>
 	/// <release>1.5</release>
 	Infographic = 59639,
+
+	/// <summary>Information (Filled)</summary>
+	/// <remarks>Category: Symbols<br/>
+	/// Alias: 1.5.0, symbols, about, help, tooltip, filled</remarks>
+	/// <release>1.5</release>
+	InformationFilled = 59640,
 
 	/// <summary>Information</summary>
 	/// <remarks>Category: Symbols<br/>
@@ -3524,6 +3626,12 @@ public enum CalciteIcon : ushort
 	/// <release>2.7.0</release>
 	Locator = 59737,
 
+	/// <summary>Lock (Filled)</summary>
+	/// <remarks>Category: Objects<br/>
+	/// Alias: 1.5.0, objects, secure, guarded, permission, security, restricted, privacy, filled</remarks>
+	/// <release>1.5</release>
+	LockFilled = 59738,
+
 	/// <summary>Lock</summary>
 	/// <remarks>Category: Objects<br/>
 	/// Alias: 1.5.0, objects, secure, guarded, permission, security, restricted, privacy</remarks>
@@ -3770,11 +3878,23 @@ public enum CalciteIcon : ushort
 	/// <release>1.5</release>
 	Minus = 59779,
 
+	/// <summary>Minus Circle (Filled)</summary>
+	/// <remarks>Category: Symbols<br/>
+	/// Alias: 3.24.2, symbols, stop, delete, remove, restricted, subtract, filled</remarks>
+	/// <release>3.24.2</release>
+	MinusCircleFilled = 59780,
+
 	/// <summary>Minus Circle</summary>
 	/// <remarks>Category: Symbols<br/>
 	/// Alias: 3.24.2, symbols, stop, delete, remove, restricted, subtract</remarks>
 	/// <release>3.24.2</release>
 	MinusCircle = 59781,
+
+	/// <summary>Minus Square (Filled)</summary>
+	/// <remarks>Category: Symbols<br/>
+	/// Alias: 3.23.6, symbols, hyphen, line, filled, subtract, filled</remarks>
+	/// <release>3.23.6</release>
+	MinusSquareFilled = 59782,
 
 	/// <summary>Minus Square</summary>
 	/// <remarks>Category: Symbols<br/>
@@ -4280,6 +4400,12 @@ public enum CalciteIcon : ushort
 	/// <release>3.28.0</release>
 	PasteWithoutAttribute = 59866,
 
+	/// <summary>Pause (Filled)</summary>
+	/// <remarks>Category: Media<br/>
+	/// Alias: 1.5.0, media, filled</remarks>
+	/// <release>1.5</release>
+	PauseFilled = 59867,
+
 	/// <summary>Pause</summary>
 	/// <remarks>Category: Media<br/>
 	/// Alias: 1.5.0, media</remarks>
@@ -4394,6 +4520,12 @@ public enum CalciteIcon : ushort
 	/// <release>1.5</release>
 	PinPlus = 59886,
 
+	/// <summary>Pin Tear (Filled)</summary>
+	/// <remarks>Category: Generic<br/>
+	/// Alias: 3.16.1, generic, location, map pin, map marker, destination, dropped pin, drop pin, filled</remarks>
+	/// <release>3.16.1</release>
+	PinTearFilled = 59887,
+
 	/// <summary>Pin Tear</summary>
 	/// <remarks>Category: Generic<br/>
 	/// Alias: 3.16.1, generic, location, map pin, map marker, destination, dropped pin, drop pin</remarks>
@@ -4417,6 +4549,12 @@ public enum CalciteIcon : ushort
 	/// Alias: 3.0.0, blueprint, layout, measurements, perimeter, width, height, boundary, interior, scale</remarks>
 	/// <release>3.0.0</release>
 	Plans = 59891,
+
+	/// <summary>Play (Filled)</summary>
+	/// <remarks>Category: Media<br/>
+	/// Alias: 1.5.0, media, run, test, filled</remarks>
+	/// <release>1.5</release>
+	PlayFilled = 59892,
 
 	/// <summary>Play</summary>
 	/// <remarks>Category: Media<br/>
@@ -4610,6 +4748,12 @@ public enum CalciteIcon : ushort
 	/// <release>3.25.8</release>
 	Query = 59924,
 
+	/// <summary>Question (Filled)</summary>
+	/// <remarks>Category: Symbols<br/>
+	/// Alias: 1.5.0, symbols, faq, unknown, help, hint, filled</remarks>
+	/// <release>1.5</release>
+	QuestionFilled = 59925,
+
 	/// <summary>Question</summary>
 	/// <remarks>Category: Symbols<br/>
 	/// Alias: 1.5.0, symbols, faq, unknown, help, hint</remarks>
@@ -4627,6 +4771,9 @@ public enum CalciteIcon : ushort
 	/// Alias: 3.3.0, quotation marks, reference</remarks>
 	/// <release>3.3.0</release>
 	Quote = 59928,
+
+	/// <summary>Radial Tree Link Chart Yayout</summary>
+	RadialTreeLinkChartYayout = 59929,
 
 	/// <summary>Rain</summary>
 	/// <remarks>Category: Weather<br/>
@@ -4825,6 +4972,12 @@ public enum CalciteIcon : ushort
 	/// Alias: gis, 3.17.1, geoai, train</remarks>
 	/// <release>3.17.1</release>
 	Retrain = 59962,
+
+	/// <summary>Reverse (Filled)</summary>
+	/// <remarks>Category: Media<br/>
+	/// Alias: 1.5.0, media, filled</remarks>
+	/// <release>1.5</release>
+	ReverseFilled = 59963,
 
 	/// <summary>Reverse</summary>
 	/// <remarks>Category: Media<br/>
@@ -5564,6 +5717,12 @@ public enum CalciteIcon : ushort
 	/// <release>3.25.2</release>
 	SplitUnits = 60086,
 
+	/// <summary>Square (Filled)</summary>
+	/// <remarks>Category: Generic<br/>
+	/// Alias: 1.5.0, generic, shapes, box, container, filled</remarks>
+	/// <release>1.5</release>
+	SquareFilled = 60087,
+
 	/// <summary>Square</summary>
 	/// <remarks>Category: Generic<br/>
 	/// Alias: 1.5.0, generic, shapes, box, container</remarks>
@@ -5606,6 +5765,12 @@ public enum CalciteIcon : ushort
 	/// <release>3.22.1</release>
 	StairsUp = 60094,
 
+	/// <summary>Star (Filled)</summary>
+	/// <remarks>Category: Symbols<br/>
+	/// Alias: 3.3.0, symbols, favorite, rate, rating, filled</remarks>
+	/// <release>3.3.0</release>
+	StarFilled = 60095,
+
 	/// <summary>Star</summary>
 	/// <remarks>Category: Symbols<br/>
 	/// Alias: 3.3.0, symbols, favorite, rate, rating</remarks>
@@ -5623,6 +5788,12 @@ public enum CalciteIcon : ushort
 	/// Alias: 3.25.2, symbols, online model builder, stopping, slow, stopped, hold</remarks>
 	/// <release>3.25.2</release>
 	Stop = 60098,
+
+	/// <summary>Stop Square (Filled)</summary>
+	/// <remarks>Category: Media<br/>
+	/// Alias: 3.24.1, media, cube, stop, halt, end, finish, filled</remarks>
+	/// <release>3.24.1</release>
+	StopSquareFilled = 60099,
 
 	/// <summary>Stop Square</summary>
 	/// <remarks>Category: Media<br/>
@@ -5990,6 +6161,12 @@ public enum CalciteIcon : ushort
 	/// <release>3.29.4</release>
 	TracePathComplete = 60160,
 
+	/// <summary>Transcript (Filled)</summary>
+	/// <remarks>Category: Media<br/>
+	/// Alias: 3.29.3, media, captions, text, video, display, speech, filled</remarks>
+	/// <release>3.29.3</release>
+	TranscriptFilled = 60161,
+
 	/// <summary>Transcript</summary>
 	/// <remarks>Category: Media<br/>
 	/// Alias: 3.29.3, media, captions, text, video, display, speech</remarks>
@@ -6356,6 +6533,9 @@ public enum CalciteIcon : ushort
 	/// <release>1.5</release>
 	Web = 60222,
 
+	/// <summary>Web Adaptor</summary>
+	WebAdaptor = 60223,
+
 	/// <summary>Webhook</summary>
 	/// <remarks>Category: Symbols<br/>
 	/// Alias: 3.14.0, symbols, web hook, event, information, manage, create, http request, payload, application, push</remarks>
@@ -6428,11 +6608,23 @@ public enum CalciteIcon : ushort
 	/// <release>3.1.0</release>
 	XBar = 60235,
 
+	/// <summary>X Circle (Filled)</summary>
+	/// <remarks>Category: Symbols<br/>
+	/// Alias: 3.8.1, symbols, delete, remove, close, filled</remarks>
+	/// <release>3.8.1</release>
+	XCircleFilled = 60236,
+
 	/// <summary>X Circle</summary>
 	/// <remarks>Category: Symbols<br/>
 	/// Alias: 3.8.1, symbols, delete, remove, close</remarks>
 	/// <release>3.8.1</release>
 	XCircle = 60237,
+
+	/// <summary>X Octagon (Filled)</summary>
+	/// <remarks>Category: Symbols<br/>
+	/// Alias: 3.11.0, x octagon, invalid, error, broken, critical, denied, restricted, filled</remarks>
+	/// <release>3.11.0</release>
+	XOctagonFilled = 60238,
 
 	/// <summary>X Octagon</summary>
 	/// <remarks>Category: Symbols<br/>

--- a/GeneratedResources/WPF/CalciteIcon.cs
+++ b/GeneratedResources/WPF/CalciteIcon.cs
@@ -4772,9 +4772,6 @@ public enum CalciteIcon : ushort
 	/// <release>3.3.0</release>
 	Quote = 59928,
 
-	/// <summary>Radial Tree Link Chart Yayout</summary>
-	RadialTreeLinkChartYayout = 59929,
-
 	/// <summary>Rain</summary>
 	/// <remarks>Category: Weather<br/>
 	/// Alias: 3.17.6, generic, clouds, weather, sky, forecast, temperature, environment, nature, precipitation, wind, stormy, clouds</remarks>

--- a/GeneratedResources/WPF/IconHelpers.cs
+++ b/GeneratedResources/WPF/IconHelpers.cs
@@ -1,4 +1,4 @@
-// COPYRIGHT © 2025 Esri
+// COPYRIGHT ï¿½ 2025 Esri
 // All rights reserved under the copyright laws of the United States and applicable international laws, treaties, and conventions.
 // This material is licensed for use under the Esri Master License Agreement (MLA), and is bound by the terms of that agreement.
 // You may redistribute and use this code without modification, provided you adhere to the terms of the MLA and include this copyright notice.
@@ -48,6 +48,7 @@ internal static class IconHelpers
 			case CalciteIcon.AddText: return "AddText";
 			case CalciteIcon.AddToModel: return "AddToModel";
 			case CalciteIcon.AddressBook: return "AddressBook";
+			case CalciteIcon.AlertOffCircleFilled: return "AlertOffCircleFilled";
 			case CalciteIcon.AllServers: return "AllServers";
 			case CalciteIcon.Altitude: return "Altitude";
 			case CalciteIcon.Analysis: return "Analysis";
@@ -102,7 +103,9 @@ internal static class IconHelpers
 			case CalciteIcon.Beaker: return "Beaker";
 			case CalciteIcon.BearLeft: return "BearLeft";
 			case CalciteIcon.BearRight: return "BearRight";
+			case CalciteIcon.BeginningFilled: return "BeginningFilled";
 			case CalciteIcon.Beginning: return "Beginning";
+			case CalciteIcon.BellFilled: return "BellFilled";
 			case CalciteIcon.Bell: return "Bell";
 			case CalciteIcon.BellOff: return "BellOff";
 			case CalciteIcon.Beta: return "Beta";
@@ -161,10 +164,12 @@ internal static class IconHelpers
 			case CalciteIcon.ChartGear: return "ChartGear";
 			case CalciteIcon.ChartMagnifyingGlass: return "ChartMagnifyingGlass";
 			case CalciteIcon.Check: return "Check";
+			case CalciteIcon.CheckCircleFilled: return "CheckCircleFilled";
 			case CalciteIcon.CheckCircle: return "CheckCircle";
 			case CalciteIcon.CheckExtent: return "CheckExtent";
 			case CalciteIcon.CheckLayer: return "CheckLayer";
 			case CalciteIcon.CheckShield: return "CheckShield";
+			case CalciteIcon.CheckSquareFilled: return "CheckSquareFilled";
 			case CalciteIcon.CheckSquare: return "CheckSquare";
 			case CalciteIcon.ChevronDown: return "ChevronDown";
 			case CalciteIcon.ChevronDownLeft: return "ChevronDownLeft";
@@ -181,12 +186,15 @@ internal static class IconHelpers
 			case CalciteIcon.ChevronsRight: return "ChevronsRight";
 			case CalciteIcon.ChevronsUp: return "ChevronsUp";
 			case CalciteIcon.ChordDiagram: return "ChordDiagram";
+			case CalciteIcon.CircleFilled: return "CircleFilled";
 			case CalciteIcon.Circle: return "Circle";
 			case CalciteIcon.CircleDisallowed: return "CircleDisallowed";
 			case CalciteIcon.CircleInsetLarge: return "CircleInsetLarge";
 			case CalciteIcon.CircleInsetMedium: return "CircleInsetMedium";
 			case CalciteIcon.CircleInsetSmall: return "CircleInsetSmall";
+			case CalciteIcon.CirclePauseFilled: return "CirclePauseFilled";
 			case CalciteIcon.CirclePause: return "CirclePause";
+			case CalciteIcon.CircleStopFilled: return "CircleStopFilled";
 			case CalciteIcon.CircleStop: return "CircleStop";
 			case CalciteIcon.ClassifyObjects: return "ClassifyObjects";
 			case CalciteIcon.ClearSelection: return "ClearSelection";
@@ -196,6 +204,7 @@ internal static class IconHelpers
 			case CalciteIcon.ClockDown: return "ClockDown";
 			case CalciteIcon.ClockForward: return "ClockForward";
 			case CalciteIcon.ClockUp: return "ClockUp";
+			case CalciteIcon.ClosedCaptionFilled: return "ClosedCaptionFilled";
 			case CalciteIcon.ClosedCaption: return "ClosedCaption";
 			case CalciteIcon.Cloud: return "Cloud";
 			case CalciteIcon.CloudData: return "CloudData";
@@ -322,6 +331,7 @@ internal static class IconHelpers
 			case CalciteIcon.EmbeddedLiveContent: return "EmbeddedLiveContent";
 			case CalciteIcon.EmployeeId: return "EmployeeId";
 			case CalciteIcon.EnableDisableFeatureSelection: return "EnableDisableFeatureSelection";
+			case CalciteIcon.EndFilled: return "EndFilled";
 			case CalciteIcon.End: return "End";
 			case CalciteIcon.Envelope: return "Envelope";
 			case CalciteIcon.Erase: return "Erase";
@@ -329,7 +339,9 @@ internal static class IconHelpers
 			case CalciteIcon.EscalatorDown: return "EscalatorDown";
 			case CalciteIcon.EscalatorUp: return "EscalatorUp";
 			case CalciteIcon.Event: return "Event";
+			case CalciteIcon.ExclamationMarkCircleFilled: return "ExclamationMarkCircleFilled";
 			case CalciteIcon.ExclamationMarkCircle: return "ExclamationMarkCircle";
+			case CalciteIcon.ExclamationMarkTriangleFilled: return "ExclamationMarkTriangleFilled";
 			case CalciteIcon.ExclamationMarkTriangle: return "ExclamationMarkTriangle";
 			case CalciteIcon.ExclamationPointFilled: return "ExclamationPointFilled";
 			case CalciteIcon.ExclamationPoint: return "ExclamationPoint";
@@ -377,6 +389,7 @@ internal static class IconHelpers
 			case CalciteIcon.Filter: return "Filter";
 			case CalciteIcon.FilterExpand: return "FilterExpand";
 			case CalciteIcon.Fingerprint: return "Fingerprint";
+			case CalciteIcon.FlagFilled: return "FlagFilled";
 			case CalciteIcon.Flag: return "Flag";
 			case CalciteIcon.FlagSlash: return "FlagSlash";
 			case CalciteIcon.Flash: return "Flash";
@@ -410,6 +423,7 @@ internal static class IconHelpers
 			case CalciteIcon.FormField: return "FormField";
 			case CalciteIcon.FormFieldMultiline: return "FormFieldMultiline";
 			case CalciteIcon.FormFieldOff: return "FormFieldOff";
+			case CalciteIcon.ForwardFilled: return "ForwardFilled";
 			case CalciteIcon.Forward: return "Forward";
 			case CalciteIcon.FrameExport: return "FrameExport";
 			case CalciteIcon.Freehand: return "Freehand";
@@ -431,6 +445,7 @@ internal static class IconHelpers
 			case CalciteIcon.GisServer: return "GisServer";
 			case CalciteIcon.Globe: return "Globe";
 			case CalciteIcon.GpsOff: return "GpsOff";
+			case CalciteIcon.GpsOnFilled: return "GpsOnFilled";
 			case CalciteIcon.GpsOn: return "GpsOn";
 			case CalciteIcon.GraphAxis: return "GraphAxis";
 			case CalciteIcon.GraphBar100Stacked: return "GraphBar100Stacked";
@@ -464,6 +479,7 @@ internal static class IconHelpers
 			case CalciteIcon.HeadingLayout: return "HeadingLayout";
 			case CalciteIcon.HeadingRtl: return "HeadingRtl";
 			case CalciteIcon.Headset: return "Headset";
+			case CalciteIcon.HeartFilled: return "HeartFilled";
 			case CalciteIcon.Heart: return "Heart";
 			case CalciteIcon.HeatChart: return "HeatChart";
 			case CalciteIcon.HeavyRain: return "HeavyRain";
@@ -504,6 +520,7 @@ internal static class IconHelpers
 			case CalciteIcon.IncreaseLinkChartSymbolSize: return "IncreaseLinkChartSymbolSize";
 			case CalciteIcon.Indicator: return "Indicator";
 			case CalciteIcon.Infographic: return "Infographic";
+			case CalciteIcon.InformationFilled: return "InformationFilled";
 			case CalciteIcon.Information: return "Information";
 			case CalciteIcon.InformationLetter: return "InformationLetter";
 			case CalciteIcon.Initiative: return "Initiative";
@@ -601,6 +618,7 @@ internal static class IconHelpers
 			case CalciteIcon.LocationSharing: return "LocationSharing";
 			case CalciteIcon.LocationSharingOff: return "LocationSharingOff";
 			case CalciteIcon.Locator: return "Locator";
+			case CalciteIcon.LockFilled: return "LockFilled";
 			case CalciteIcon.Lock: return "Lock";
 			case CalciteIcon.LtrElementsAlign: return "LtrElementsAlign";
 			case CalciteIcon.LtrParagraphAlign: return "LtrParagraphAlign";
@@ -642,7 +660,9 @@ internal static class IconHelpers
 			case CalciteIcon.Minimum: return "Minimum";
 			case CalciteIcon.MinimumGraph: return "MinimumGraph";
 			case CalciteIcon.Minus: return "Minus";
+			case CalciteIcon.MinusCircleFilled: return "MinusCircleFilled";
 			case CalciteIcon.MinusCircle: return "MinusCircle";
+			case CalciteIcon.MinusSquareFilled: return "MinusSquareFilled";
 			case CalciteIcon.MinusSquare: return "MinusSquare";
 			case CalciteIcon.MiscellaneousCollection: return "MiscellaneousCollection";
 			case CalciteIcon.MissionServer: return "MissionServer";
@@ -727,6 +747,7 @@ internal static class IconHelpers
 			case CalciteIcon.Paste: return "Paste";
 			case CalciteIcon.PasteWithAttribute: return "PasteWithAttribute";
 			case CalciteIcon.PasteWithoutAttribute: return "PasteWithoutAttribute";
+			case CalciteIcon.PauseFilled: return "PauseFilled";
 			case CalciteIcon.Pause: return "Pause";
 			case CalciteIcon.Pen: return "Pen";
 			case CalciteIcon.PenMark: return "PenMark";
@@ -746,10 +767,12 @@ internal static class IconHelpers
 			case CalciteIcon.PieChart: return "PieChart";
 			case CalciteIcon.Pin: return "Pin";
 			case CalciteIcon.PinPlus: return "PinPlus";
+			case CalciteIcon.PinTearFilled: return "PinTearFilled";
 			case CalciteIcon.PinTear: return "PinTear";
 			case CalciteIcon.Pins: return "Pins";
 			case CalciteIcon.Plane: return "Plane";
 			case CalciteIcon.Plans: return "Plans";
+			case CalciteIcon.PlayFilled: return "PlayFilled";
 			case CalciteIcon.Play: return "Play";
 			case CalciteIcon.Plus: return "Plus";
 			case CalciteIcon.PlusCircle: return "PlusCircle";
@@ -782,9 +805,11 @@ internal static class IconHelpers
 			case CalciteIcon.QrCode: return "QrCode";
 			case CalciteIcon.QtCode: return "QtCode";
 			case CalciteIcon.Query: return "Query";
+			case CalciteIcon.QuestionFilled: return "QuestionFilled";
 			case CalciteIcon.Question: return "Question";
 			case CalciteIcon.QuestionMark: return "QuestionMark";
 			case CalciteIcon.Quote: return "Quote";
+			case CalciteIcon.RadialTreeLinkChartYayout: return "RadialTreeLinkChartYayout";
 			case CalciteIcon.Rain: return "Rain";
 			case CalciteIcon.RainSnow: return "RainSnow";
 			case CalciteIcon.RainThunder: return "RainThunder";
@@ -818,6 +843,7 @@ internal static class IconHelpers
 			case CalciteIcon.ReshapeTool: return "ReshapeTool";
 			case CalciteIcon.ResizeArea: return "ResizeArea";
 			case CalciteIcon.Retrain: return "Retrain";
+			case CalciteIcon.ReverseFilled: return "ReverseFilled";
 			case CalciteIcon.Reverse: return "Reverse";
 			case CalciteIcon.Rfid: return "Rfid";
 			case CalciteIcon.Rhombus: return "Rhombus";
@@ -941,6 +967,7 @@ internal static class IconHelpers
 			case CalciteIcon.SplitFeatures: return "SplitFeatures";
 			case CalciteIcon.SplitGeometry: return "SplitGeometry";
 			case CalciteIcon.SplitUnits: return "SplitUnits";
+			case CalciteIcon.SquareFilled: return "SquareFilled";
 			case CalciteIcon.Square: return "Square";
 			case CalciteIcon.SquareInsetLarge: return "SquareInsetLarge";
 			case CalciteIcon.SquareInsetMedium: return "SquareInsetMedium";
@@ -948,9 +975,11 @@ internal static class IconHelpers
 			case CalciteIcon.Stairs: return "Stairs";
 			case CalciteIcon.StairsDown: return "StairsDown";
 			case CalciteIcon.StairsUp: return "StairsUp";
+			case CalciteIcon.StarFilled: return "StarFilled";
 			case CalciteIcon.Star: return "Star";
 			case CalciteIcon.StarCircle: return "StarCircle";
 			case CalciteIcon.Stop: return "Stop";
+			case CalciteIcon.StopSquareFilled: return "StopSquareFilled";
 			case CalciteIcon.StopSquare: return "StopSquare";
 			case CalciteIcon.Storage: return "Storage";
 			case CalciteIcon.StoredAsNewQuery: return "StoredAsNewQuery";
@@ -1012,6 +1041,7 @@ internal static class IconHelpers
 			case CalciteIcon.Trace: return "Trace";
 			case CalciteIcon.TracePath: return "TracePath";
 			case CalciteIcon.TracePathComplete: return "TracePathComplete";
+			case CalciteIcon.TranscriptFilled: return "TranscriptFilled";
 			case CalciteIcon.Transcript: return "Transcript";
 			case CalciteIcon.TransverseHexagon: return "TransverseHexagon";
 			case CalciteIcon.Trash: return "Trash";
@@ -1073,6 +1103,7 @@ internal static class IconHelpers
 			case CalciteIcon.WalkingDistance: return "WalkingDistance";
 			case CalciteIcon.WalkingTime: return "WalkingTime";
 			case CalciteIcon.Web: return "Web";
+			case CalciteIcon.WebAdaptor: return "WebAdaptor";
 			case CalciteIcon.Webhook: return "Webhook";
 			case CalciteIcon.Wheelchair: return "Wheelchair";
 			case CalciteIcon.WidgetsGroup: return "WidgetsGroup";
@@ -1085,7 +1116,9 @@ internal static class IconHelpers
 			case CalciteIcon.X: return "X";
 			case CalciteIcon.XAxisGuide: return "XAxisGuide";
 			case CalciteIcon.XBar: return "XBar";
+			case CalciteIcon.XCircleFilled: return "XCircleFilled";
 			case CalciteIcon.XCircle: return "XCircle";
+			case CalciteIcon.XOctagonFilled: return "XOctagonFilled";
 			case CalciteIcon.XOctagon: return "XOctagon";
 			case CalciteIcon.YAxisGuide: return "YAxisGuide";
 			case CalciteIcon.ZoomInFixed: return "ZoomInFixed";

--- a/GeneratedResources/WPF/IconHelpers.cs
+++ b/GeneratedResources/WPF/IconHelpers.cs
@@ -809,7 +809,6 @@ internal static class IconHelpers
 			case CalciteIcon.Question: return "Question";
 			case CalciteIcon.QuestionMark: return "QuestionMark";
 			case CalciteIcon.Quote: return "Quote";
-			case CalciteIcon.RadialTreeLinkChartYayout: return "RadialTreeLinkChartYayout";
 			case CalciteIcon.Rain: return "Rain";
 			case CalciteIcon.RainSnow: return "RainSnow";
 			case CalciteIcon.RainThunder: return "RainThunder";

--- a/GeneratedResources/WPF/Icons/Glyphs.xaml
+++ b/GeneratedResources/WPF/Icons/Glyphs.xaml
@@ -32,6 +32,7 @@
     <system:String x:Key="CalciteUIIcons_Glyph_AddText">&#xe71d;</system:String> 
     <system:String x:Key="CalciteUIIcons_Glyph_AddToModel">&#xe71e;</system:String> 
     <system:String x:Key="CalciteUIIcons_Glyph_AddressBook">&#xe71f;</system:String> 
+    <system:String x:Key="CalciteUIIcons_Glyph_AlertOffCircleFilled">&#xe720;</system:String> 
     <system:String x:Key="CalciteUIIcons_Glyph_AllServers">&#xe721;</system:String> 
     <system:String x:Key="CalciteUIIcons_Glyph_Altitude">&#xe722;</system:String> 
     <system:String x:Key="CalciteUIIcons_Glyph_Analysis">&#xe723;</system:String> 
@@ -89,7 +90,9 @@
     <system:String x:Key="CalciteUIIcons_Glyph_BearLeft">&#xe755;</system:String> 
     <system:String x:Key="CalciteUIIcons_Glyph_BearRight">&#xe756;</system:String> 
     <system:String x:Key="CalciteUIIcons_Glyph_Beginning">&#xe758;</system:String> 
+    <system:String x:Key="CalciteUIIcons_Glyph_BeginningFilled">&#xe757;</system:String> 
     <system:String x:Key="CalciteUIIcons_Glyph_Bell">&#xe75a;</system:String> 
+    <system:String x:Key="CalciteUIIcons_Glyph_BellFilled">&#xe759;</system:String> 
     <system:String x:Key="CalciteUIIcons_Glyph_BellOff">&#xe75b;</system:String> 
     <system:String x:Key="CalciteUIIcons_Glyph_Beta">&#xe75c;</system:String> 
     <system:String x:Key="CalciteUIIcons_Glyph_Biking">&#xe75d;</system:String> 
@@ -154,10 +157,12 @@
     <system:String x:Key="CalciteUIIcons_Glyph_ChartMagnifyingGlass">&#xe792;</system:String> 
     <system:String x:Key="CalciteUIIcons_Glyph_Check">&#xe793;</system:String> 
     <system:String x:Key="CalciteUIIcons_Glyph_CheckCircle">&#xe795;</system:String> 
+    <system:String x:Key="CalciteUIIcons_Glyph_CheckCircleFilled">&#xe794;</system:String> 
     <system:String x:Key="CalciteUIIcons_Glyph_CheckExtent">&#xe796;</system:String> 
     <system:String x:Key="CalciteUIIcons_Glyph_CheckLayer">&#xe797;</system:String> 
     <system:String x:Key="CalciteUIIcons_Glyph_CheckShield">&#xe798;</system:String> 
     <system:String x:Key="CalciteUIIcons_Glyph_CheckSquare">&#xe79a;</system:String> 
+    <system:String x:Key="CalciteUIIcons_Glyph_CheckSquareFilled">&#xe799;</system:String> 
     <system:String x:Key="CalciteUIIcons_Glyph_ChevronDown">&#xe79b;</system:String> 
     <system:String x:Key="CalciteUIIcons_Glyph_ChevronDownLeft">&#xe79c;</system:String> 
     <system:String x:Key="CalciteUIIcons_Glyph_ChevronDownRight">&#xe79d;</system:String> 
@@ -174,13 +179,16 @@
     <system:String x:Key="CalciteUIIcons_Glyph_ChevronsUp">&#xe7a8;</system:String> 
     <system:String x:Key="CalciteUIIcons_Glyph_ChordDiagram">&#xe7a9;</system:String> 
     <system:String x:Key="CalciteUIIcons_Glyph_Circle">&#xe7ab;</system:String> 
+    <system:String x:Key="CalciteUIIcons_Glyph_CircleFilled">&#xe7aa;</system:String> 
     <system:String x:Key="CalciteUIIcons_Glyph_CircleAreaHashFilled">&#xeb74;</system:String> 
     <system:String x:Key="CalciteUIIcons_Glyph_CircleDisallowed">&#xe7ac;</system:String> 
     <system:String x:Key="CalciteUIIcons_Glyph_CircleInsetLarge">&#xe7ad;</system:String> 
     <system:String x:Key="CalciteUIIcons_Glyph_CircleInsetMedium">&#xe7ae;</system:String> 
     <system:String x:Key="CalciteUIIcons_Glyph_CircleInsetSmall">&#xe7af;</system:String> 
     <system:String x:Key="CalciteUIIcons_Glyph_CirclePause">&#xe7b1;</system:String> 
+    <system:String x:Key="CalciteUIIcons_Glyph_CirclePauseFilled">&#xe7b0;</system:String> 
     <system:String x:Key="CalciteUIIcons_Glyph_CircleStop">&#xe7b3;</system:String> 
+    <system:String x:Key="CalciteUIIcons_Glyph_CircleStopFilled">&#xe7b2;</system:String> 
     <system:String x:Key="CalciteUIIcons_Glyph_ClassifyObjects">&#xe7b4;</system:String> 
     <system:String x:Key="CalciteUIIcons_Glyph_ClearSelection">&#xe7b5;</system:String> 
     <system:String x:Key="CalciteUIIcons_Glyph_Clipboard">&#xe7b6;</system:String> 
@@ -190,6 +198,7 @@
     <system:String x:Key="CalciteUIIcons_Glyph_ClockForward">&#xe7ba;</system:String> 
     <system:String x:Key="CalciteUIIcons_Glyph_ClockUp">&#xe7bb;</system:String> 
     <system:String x:Key="CalciteUIIcons_Glyph_ClosedCaption">&#xe7bd;</system:String> 
+    <system:String x:Key="CalciteUIIcons_Glyph_ClosedCaptionFilled">&#xe7bc;</system:String> 
     <system:String x:Key="CalciteUIIcons_Glyph_Cloud">&#xe7be;</system:String> 
     <system:String x:Key="CalciteUIIcons_Glyph_CloudData">&#xe7bf;</system:String> 
     <system:String x:Key="CalciteUIIcons_Glyph_CloudServer">&#xe7c0;</system:String> 
@@ -330,6 +339,7 @@
     <system:String x:Key="CalciteUIIcons_Glyph_EmployeeId">&#xe839;</system:String> 
     <system:String x:Key="CalciteUIIcons_Glyph_EnableDisableFeatureSelection">&#xe83a;</system:String> 
     <system:String x:Key="CalciteUIIcons_Glyph_End">&#xe83c;</system:String> 
+    <system:String x:Key="CalciteUIIcons_Glyph_EndFilled">&#xe83b;</system:String> 
     <system:String x:Key="CalciteUIIcons_Glyph_Envelope">&#xe83d;</system:String> 
     <system:String x:Key="CalciteUIIcons_Glyph_Erase">&#xe83e;</system:String> 
     <system:String x:Key="CalciteUIIcons_Glyph_Escalator">&#xe83f;</system:String> 
@@ -337,7 +347,9 @@
     <system:String x:Key="CalciteUIIcons_Glyph_EscalatorUp">&#xe841;</system:String> 
     <system:String x:Key="CalciteUIIcons_Glyph_Event">&#xe842;</system:String> 
     <system:String x:Key="CalciteUIIcons_Glyph_ExclamationMarkCircle">&#xe844;</system:String> 
+    <system:String x:Key="CalciteUIIcons_Glyph_ExclamationMarkCircleFilled">&#xe843;</system:String> 
     <system:String x:Key="CalciteUIIcons_Glyph_ExclamationMarkTriangle">&#xe846;</system:String> 
+    <system:String x:Key="CalciteUIIcons_Glyph_ExclamationMarkTriangleFilled">&#xe845;</system:String> 
     <system:String x:Key="CalciteUIIcons_Glyph_ExclamationPoint">&#xe848;</system:String> 
     <system:String x:Key="CalciteUIIcons_Glyph_ExclamationPointFilled">&#xe847;</system:String> 
     <system:String x:Key="CalciteUIIcons_Glyph_ExitHighwayLeft">&#xe849;</system:String> 
@@ -387,6 +399,7 @@
     <system:String x:Key="CalciteUIIcons_Glyph_FindAddPath">&#xf118;</system:String> 
     <system:String x:Key="CalciteUIIcons_Glyph_Fingerprint">&#xe874;</system:String> 
     <system:String x:Key="CalciteUIIcons_Glyph_Flag">&#xe876;</system:String> 
+    <system:String x:Key="CalciteUIIcons_Glyph_FlagFilled">&#xe875;</system:String> 
     <system:String x:Key="CalciteUIIcons_Glyph_FlagSlash">&#xe877;</system:String> 
     <system:String x:Key="CalciteUIIcons_Glyph_Flash">&#xe878;</system:String> 
     <system:String x:Key="CalciteUIIcons_Glyph_Flip">&#xe879;</system:String> 
@@ -420,6 +433,7 @@
     <system:String x:Key="CalciteUIIcons_Glyph_FormFieldMultiline">&#xe895;</system:String> 
     <system:String x:Key="CalciteUIIcons_Glyph_FormFieldOff">&#xe896;</system:String> 
     <system:String x:Key="CalciteUIIcons_Glyph_Forward">&#xe898;</system:String> 
+    <system:String x:Key="CalciteUIIcons_Glyph_ForwardFilled">&#xe897;</system:String> 
     <system:String x:Key="CalciteUIIcons_Glyph_FourTimes">&#xe708;</system:String> 
     <system:String x:Key="CalciteUIIcons_Glyph_FrameExport">&#xe899;</system:String> 
     <system:String x:Key="CalciteUIIcons_Glyph_Freehand">&#xe89a;</system:String> 
@@ -443,6 +457,7 @@
     <system:String x:Key="CalciteUIIcons_Glyph_GovernmentBuilding">&#xeb76;</system:String> 
     <system:String x:Key="CalciteUIIcons_Glyph_GpsOff">&#xe8ac;</system:String> 
     <system:String x:Key="CalciteUIIcons_Glyph_GpsOn">&#xe8ae;</system:String> 
+    <system:String x:Key="CalciteUIIcons_Glyph_GpsOnFilled">&#xe8ad;</system:String> 
     <system:String x:Key="CalciteUIIcons_Glyph_GraphAxis">&#xe8af;</system:String> 
     <system:String x:Key="CalciteUIIcons_Glyph_GraphBar">&#xe8b1;</system:String> 
     <system:String x:Key="CalciteUIIcons_Glyph_GraphBar100Stacked">&#xe8b0;</system:String> 
@@ -478,6 +493,7 @@
     <system:String x:Key="CalciteUIIcons_Glyph_HeadingRtl">&#xe8cd;</system:String> 
     <system:String x:Key="CalciteUIIcons_Glyph_Headset">&#xe8ce;</system:String> 
     <system:String x:Key="CalciteUIIcons_Glyph_Heart">&#xe8d0;</system:String> 
+    <system:String x:Key="CalciteUIIcons_Glyph_HeartFilled">&#xe8cf;</system:String> 
     <system:String x:Key="CalciteUIIcons_Glyph_HeatChart">&#xe8d1;</system:String> 
     <system:String x:Key="CalciteUIIcons_Glyph_HeavyRain">&#xe8d2;</system:String> 
     <system:String x:Key="CalciteUIIcons_Glyph_HeavySnow">&#xe8d3;</system:String> 
@@ -521,6 +537,7 @@
     <system:String x:Key="CalciteUIIcons_Glyph_Indicator">&#xe8f6;</system:String> 
     <system:String x:Key="CalciteUIIcons_Glyph_Infographic">&#xe8f7;</system:String> 
     <system:String x:Key="CalciteUIIcons_Glyph_Information">&#xe8f9;</system:String> 
+    <system:String x:Key="CalciteUIIcons_Glyph_InformationFilled">&#xe8f8;</system:String> 
     <system:String x:Key="CalciteUIIcons_Glyph_InformationLetter">&#xe8fa;</system:String> 
     <system:String x:Key="CalciteUIIcons_Glyph_Initiative">&#xe8fb;</system:String> 
     <system:String x:Key="CalciteUIIcons_Glyph_InitiativeTemplate">&#xeb5f;</system:String> 
@@ -630,6 +647,7 @@
     <system:String x:Key="CalciteUIIcons_Glyph_LocationSharingOff">&#xe958;</system:String> 
     <system:String x:Key="CalciteUIIcons_Glyph_Locator">&#xe959;</system:String> 
     <system:String x:Key="CalciteUIIcons_Glyph_Lock">&#xe95b;</system:String> 
+    <system:String x:Key="CalciteUIIcons_Glyph_LockFilled">&#xe95a;</system:String> 
     <system:String x:Key="CalciteUIIcons_Glyph_LtrElementsAlign">&#xe95c;</system:String> 
     <system:String x:Key="CalciteUIIcons_Glyph_LtrParagraphAlign">&#xe95d;</system:String> 
     <system:String x:Key="CalciteUIIcons_Glyph_MagnifyingGlass">&#xe95e;</system:String> 
@@ -672,7 +690,9 @@
     <system:String x:Key="CalciteUIIcons_Glyph_MinimumGraph">&#xe982;</system:String> 
     <system:String x:Key="CalciteUIIcons_Glyph_Minus">&#xe983;</system:String> 
     <system:String x:Key="CalciteUIIcons_Glyph_MinusCircle">&#xe985;</system:String> 
+    <system:String x:Key="CalciteUIIcons_Glyph_MinusCircleFilled">&#xe984;</system:String> 
     <system:String x:Key="CalciteUIIcons_Glyph_MinusSquare">&#xe987;</system:String> 
+    <system:String x:Key="CalciteUIIcons_Glyph_MinusSquareFilled">&#xe986;</system:String> 
     <system:String x:Key="CalciteUIIcons_Glyph_MiscellaneousCollection">&#xe988;</system:String> 
     <system:String x:Key="CalciteUIIcons_Glyph_MissionServer">&#xe989;</system:String> 
     <system:String x:Key="CalciteUIIcons_Glyph_Mobile">&#xe98a;</system:String> 
@@ -767,6 +787,7 @@
     <system:String x:Key="CalciteUIIcons_Glyph_PasteWithAttribute">&#xe9d9;</system:String> 
     <system:String x:Key="CalciteUIIcons_Glyph_PasteWithoutAttribute">&#xe9da;</system:String> 
     <system:String x:Key="CalciteUIIcons_Glyph_Pause">&#xe9dc;</system:String> 
+    <system:String x:Key="CalciteUIIcons_Glyph_PauseFilled">&#xe9db;</system:String> 
     <system:String x:Key="CalciteUIIcons_Glyph_Pen">&#xe9dd;</system:String> 
     <system:String x:Key="CalciteUIIcons_Glyph_PenMark">&#xe9de;</system:String> 
     <system:String x:Key="CalciteUIIcons_Glyph_PenMarkPlus">&#xe9df;</system:String> 
@@ -788,10 +809,12 @@
     <system:String x:Key="CalciteUIIcons_Glyph_Pin">&#xe9ed;</system:String> 
     <system:String x:Key="CalciteUIIcons_Glyph_PinPlus">&#xe9ee;</system:String> 
     <system:String x:Key="CalciteUIIcons_Glyph_PinTear">&#xe9f0;</system:String> 
+    <system:String x:Key="CalciteUIIcons_Glyph_PinTearFilled">&#xe9ef;</system:String> 
     <system:String x:Key="CalciteUIIcons_Glyph_Pins">&#xe9f1;</system:String> 
     <system:String x:Key="CalciteUIIcons_Glyph_Plane">&#xe9f2;</system:String> 
     <system:String x:Key="CalciteUIIcons_Glyph_Plans">&#xe9f3;</system:String> 
     <system:String x:Key="CalciteUIIcons_Glyph_Play">&#xe9f5;</system:String> 
+    <system:String x:Key="CalciteUIIcons_Glyph_PlayFilled">&#xe9f4;</system:String> 
     <system:String x:Key="CalciteUIIcons_Glyph_PlugConnection">&#xf109;</system:String> 
     <system:String x:Key="CalciteUIIcons_Glyph_Plus">&#xe9f6;</system:String> 
     <system:String x:Key="CalciteUIIcons_Glyph_PlusCircle">&#xe9f7;</system:String> 
@@ -826,9 +849,11 @@
     <system:String x:Key="CalciteUIIcons_Glyph_QtCode">&#xea13;</system:String> 
     <system:String x:Key="CalciteUIIcons_Glyph_Query">&#xea14;</system:String> 
     <system:String x:Key="CalciteUIIcons_Glyph_Question">&#xea16;</system:String> 
+    <system:String x:Key="CalciteUIIcons_Glyph_QuestionFilled">&#xea15;</system:String> 
     <system:String x:Key="CalciteUIIcons_Glyph_QuestionMark">&#xea17;</system:String> 
     <system:String x:Key="CalciteUIIcons_Glyph_Quote">&#xea18;</system:String> 
     <system:String x:Key="CalciteUIIcons_Glyph_RadialTreeLinkChartLayout">&#xeb65;</system:String> 
+    <system:String x:Key="CalciteUIIcons_Glyph_RadialTreeLinkChartYayout">&#xea19;</system:String> 
     <system:String x:Key="CalciteUIIcons_Glyph_Rain">&#xea1a;</system:String> 
     <system:String x:Key="CalciteUIIcons_Glyph_RainSnow">&#xea1b;</system:String> 
     <system:String x:Key="CalciteUIIcons_Glyph_RainThunder">&#xea1c;</system:String> 
@@ -864,6 +889,7 @@
     <system:String x:Key="CalciteUIIcons_Glyph_ResizeArea">&#xea39;</system:String> 
     <system:String x:Key="CalciteUIIcons_Glyph_Retrain">&#xea3a;</system:String> 
     <system:String x:Key="CalciteUIIcons_Glyph_Reverse">&#xea3c;</system:String> 
+    <system:String x:Key="CalciteUIIcons_Glyph_ReverseFilled">&#xea3b;</system:String> 
     <system:String x:Key="CalciteUIIcons_Glyph_Rfid">&#xea3d;</system:String> 
     <system:String x:Key="CalciteUIIcons_Glyph_Rhombus">&#xea3e;</system:String> 
     <system:String x:Key="CalciteUIIcons_Glyph_Ribbon">&#xea3f;</system:String> 
@@ -998,6 +1024,7 @@
     <system:String x:Key="CalciteUIIcons_Glyph_SplitGeometry">&#xeab5;</system:String> 
     <system:String x:Key="CalciteUIIcons_Glyph_SplitUnits">&#xeab6;</system:String> 
     <system:String x:Key="CalciteUIIcons_Glyph_Square">&#xeab8;</system:String> 
+    <system:String x:Key="CalciteUIIcons_Glyph_SquareFilled">&#xeab7;</system:String> 
     <system:String x:Key="CalciteUIIcons_Glyph_SquareBracketsX">&#xeb69;</system:String> 
     <system:String x:Key="CalciteUIIcons_Glyph_SquareHashFilled">&#xeb80;</system:String> 
     <system:String x:Key="CalciteUIIcons_Glyph_SquareHashFilledArea">&#xeb7f;</system:String> 
@@ -1008,9 +1035,11 @@
     <system:String x:Key="CalciteUIIcons_Glyph_StairsDown">&#xeabd;</system:String> 
     <system:String x:Key="CalciteUIIcons_Glyph_StairsUp">&#xeabe;</system:String> 
     <system:String x:Key="CalciteUIIcons_Glyph_Star">&#xeac0;</system:String> 
+    <system:String x:Key="CalciteUIIcons_Glyph_StarFilled">&#xeabf;</system:String> 
     <system:String x:Key="CalciteUIIcons_Glyph_StarCircle">&#xeac1;</system:String> 
     <system:String x:Key="CalciteUIIcons_Glyph_Stop">&#xeac2;</system:String> 
     <system:String x:Key="CalciteUIIcons_Glyph_StopSquare">&#xeac4;</system:String> 
+    <system:String x:Key="CalciteUIIcons_Glyph_StopSquareFilled">&#xeac3;</system:String> 
     <system:String x:Key="CalciteUIIcons_Glyph_Storage">&#xeac5;</system:String> 
     <system:String x:Key="CalciteUIIcons_Glyph_StoredAsNewQuery">&#xeac6;</system:String> 
     <system:String x:Key="CalciteUIIcons_Glyph_StoredQuery">&#xeac7;</system:String> 
@@ -1072,6 +1101,7 @@
     <system:String x:Key="CalciteUIIcons_Glyph_TracePath">&#xeaff;</system:String> 
     <system:String x:Key="CalciteUIIcons_Glyph_TracePathComplete">&#xeb00;</system:String> 
     <system:String x:Key="CalciteUIIcons_Glyph_Transcript">&#xeb02;</system:String> 
+    <system:String x:Key="CalciteUIIcons_Glyph_TranscriptFilled">&#xeb01;</system:String> 
     <system:String x:Key="CalciteUIIcons_Glyph_TransverseHexagon">&#xeb03;</system:String> 
     <system:String x:Key="CalciteUIIcons_Glyph_Trash">&#xeb04;</system:String> 
     <system:String x:Key="CalciteUIIcons_Glyph_Tree">&#xeb81;</system:String> 
@@ -1140,6 +1170,7 @@
     <system:String x:Key="CalciteUIIcons_Glyph_WaterDrop">&#xeb82;</system:String> 
     <system:String x:Key="CalciteUIIcons_Glyph_Web">&#xeb3e;</system:String> 
     <system:String x:Key="CalciteUIIcons_Glyph_WebAdapter">&#xeb6b;</system:String> 
+    <system:String x:Key="CalciteUIIcons_Glyph_WebAdaptor">&#xeb3f;</system:String> 
     <system:String x:Key="CalciteUIIcons_Glyph_Webhook">&#xeb40;</system:String> 
     <system:String x:Key="CalciteUIIcons_Glyph_Wheelchair">&#xeb41;</system:String> 
     <system:String x:Key="CalciteUIIcons_Glyph_WhiteCursorSelection">&#xeb83;</system:String> 
@@ -1155,7 +1186,9 @@
     <system:String x:Key="CalciteUIIcons_Glyph_XAxisGuide">&#xeb4a;</system:String> 
     <system:String x:Key="CalciteUIIcons_Glyph_XBar">&#xeb4b;</system:String> 
     <system:String x:Key="CalciteUIIcons_Glyph_XCircle">&#xeb4d;</system:String> 
+    <system:String x:Key="CalciteUIIcons_Glyph_XCircleFilled">&#xeb4c;</system:String> 
     <system:String x:Key="CalciteUIIcons_Glyph_XOctagon">&#xeb4f;</system:String> 
+    <system:String x:Key="CalciteUIIcons_Glyph_XOctagonFilled">&#xeb4e;</system:String> 
     <system:String x:Key="CalciteUIIcons_Glyph_YAxisGuide">&#xeb50;</system:String> 
     <system:String x:Key="CalciteUIIcons_Glyph_ZoningParameter">&#xeb6c;</system:String> 
     <system:String x:Key="CalciteUIIcons_Glyph_ZoomInFixed">&#xeb51;</system:String> 

--- a/GeneratedResources/WPF/Icons/Glyphs.xaml
+++ b/GeneratedResources/WPF/Icons/Glyphs.xaml
@@ -853,7 +853,6 @@
     <system:String x:Key="CalciteUIIcons_Glyph_QuestionMark">&#xea17;</system:String> 
     <system:String x:Key="CalciteUIIcons_Glyph_Quote">&#xea18;</system:String> 
     <system:String x:Key="CalciteUIIcons_Glyph_RadialTreeLinkChartLayout">&#xeb65;</system:String> 
-    <system:String x:Key="CalciteUIIcons_Glyph_RadialTreeLinkChartYayout">&#xea19;</system:String> 
     <system:String x:Key="CalciteUIIcons_Glyph_Rain">&#xea1a;</system:String> 
     <system:String x:Key="CalciteUIIcons_Glyph_RainSnow">&#xea1b;</system:String> 
     <system:String x:Key="CalciteUIIcons_Glyph_RainThunder">&#xea1c;</system:String> 

--- a/GeneratedResources/WinUI/CalciteIcon.cs
+++ b/GeneratedResources/WinUI/CalciteIcon.cs
@@ -206,6 +206,12 @@ public enum CalciteIcon : ushort
 	/// <release>3.0.0</release>
 	AddressBook = 59167,
 
+	/// <summary>Alert Off Circle (Filled)</summary>
+	/// <remarks>Category: Objects<br/>
+	/// Alias: 3.24.2, objects, bell, no notifications, silent, vibrate, unsubscribe, turn off, no alarm, no announcements, filled</remarks>
+	/// <release>3.24.2</release>
+	AlertOffCircleFilled = 59168,
+
 	/// <summary>All Servers</summary>
 	/// <remarks>Category: GIS<br/>
 	/// Alias: 3.20.7, gis, connections, connected, networks</remarks>
@@ -530,11 +536,23 @@ public enum CalciteIcon : ushort
 	/// <release>1.5</release>
 	BearRight = 59222,
 
+	/// <summary>Beginning (Filled)</summary>
+	/// <remarks>Category: Media<br/>
+	/// Alias: 1.5.0, start, first, media, filled</remarks>
+	/// <release>1.5</release>
+	BeginningFilled = 59223,
+
 	/// <summary>Beginning</summary>
 	/// <remarks>Category: Media<br/>
 	/// Alias: 1.5.0, start, first, media</remarks>
 	/// <release>1.5</release>
 	Beginning = 59224,
+
+	/// <summary>Bell (Filled)</summary>
+	/// <remarks>Category: Objects<br/>
+	/// Alias: 3.14.5, objects, notification, alert, alarm, bell, filled</remarks>
+	/// <release>3.14.5</release>
+	BellFilled = 59225,
 
 	/// <summary>Bell</summary>
 	/// <remarks>Category: Objects<br/>
@@ -884,6 +902,12 @@ public enum CalciteIcon : ushort
 	/// <release>1.5</release>
 	Check = 59283,
 
+	/// <summary>Check Circle (Filled)</summary>
+	/// <remarks>Category: Symbols<br/>
+	/// Alias: 1.5.0, symbols, check, mark, selected, circle, filled</remarks>
+	/// <release>1.5</release>
+	CheckCircleFilled = 59284,
+
 	/// <summary>Check Circle</summary>
 	/// <remarks>Category: Symbols<br/>
 	/// Alias: 1.5.0, symbols, check, mark, selected, circle</remarks>
@@ -907,6 +931,12 @@ public enum CalciteIcon : ushort
 	/// Alias: 3.15.2, objects, safety, insurance, protection, insured, secure, security, anti-virus, cybersecurity, defense, protected, warranty, coverage</remarks>
 	/// <release>3.15.2</release>
 	CheckShield = 59288,
+
+	/// <summary>Check Square (Filled)</summary>
+	/// <remarks>Category: Symbols<br/>
+	/// Alias: 1.5.0, symbols, done, box, select, tick, check mark, toggle, confirm, correct, selected, filled</remarks>
+	/// <release>1.5</release>
+	CheckSquareFilled = 59289,
 
 	/// <summary>Check Square</summary>
 	/// <remarks>Category: Symbols<br/>
@@ -1004,6 +1034,12 @@ public enum CalciteIcon : ushort
 	/// <release>1.5</release>
 	ChordDiagram = 59305,
 
+	/// <summary>Circle (Filled)</summary>
+	/// <remarks>Category: Generic<br/>
+	/// Alias: 1.5.0, generic, radio, shape, empty, button, filled</remarks>
+	/// <release>1.5</release>
+	CircleFilled = 59306,
+
 	/// <summary>Circle</summary>
 	/// <remarks>Category: Generic<br/>
 	/// Alias: 1.5.0, generic, radio, shape, empty, button</remarks>
@@ -1034,11 +1070,23 @@ public enum CalciteIcon : ushort
 	/// <release>3.28.8</release>
 	CircleInsetSmall = 59311,
 
+	/// <summary>Circle Pause (Filled)</summary>
+	/// <remarks>Category: Symbols<br/>
+	/// Alias: 3.23.0, symbols, stop, hold, pausing, waiting, slow, status, filled</remarks>
+	/// <release>3.23.0</release>
+	CirclePauseFilled = 59312,
+
 	/// <summary>Circle Pause</summary>
 	/// <remarks>Category: Symbols<br/>
 	/// Alias: 3.23.0, symbols, stop, hold, pausing, waiting, slow, status</remarks>
 	/// <release>3.23.0</release>
 	CirclePause = 59313,
+
+	/// <summary>Circle Stop (Filled)</summary>
+	/// <remarks>Category: Symbols<br/>
+	/// Alias: 3.24.1, symbols, cube, stop, halt, end, finish, button, filled</remarks>
+	/// <release>3.24.1</release>
+	CircleStopFilled = 59314,
 
 	/// <summary>Circle Stop</summary>
 	/// <remarks>Category: Symbols<br/>
@@ -1093,6 +1141,12 @@ public enum CalciteIcon : ushort
 	/// Alias: 1.5.0, objects, time, date, sort, ascending</remarks>
 	/// <release>1.5</release>
 	ClockUp = 59323,
+
+	/// <summary>Closed Caption (Filled)</summary>
+	/// <remarks>Category: Media<br/>
+	/// Alias: 3.29.3, media, media, audio, video, display, text, information, filled</remarks>
+	/// <release>3.29.3</release>
+	ClosedCaptionFilled = 59324,
 
 	/// <summary>Closed Caption</summary>
 	/// <remarks>Category: Media<br/>
@@ -1850,6 +1904,12 @@ public enum CalciteIcon : ushort
 	/// <release>3.25.2</release>
 	EnableDisableFeatureSelection = 59450,
 
+	/// <summary>End (Filled)</summary>
+	/// <remarks>Category: Media<br/>
+	/// Alias: 1.5.0, media, filled</remarks>
+	/// <release>1.5</release>
+	EndFilled = 59451,
+
 	/// <summary>End</summary>
 	/// <remarks>Category: Media<br/>
 	/// Alias: 1.5.0, media</remarks>
@@ -1892,11 +1952,23 @@ public enum CalciteIcon : ushort
 	/// <release>3.0.0</release>
 	Event = 59458,
 
+	/// <summary>Exclamation Mark Circle (Filled)</summary>
+	/// <remarks>Category: Symbols<br/>
+	/// Alias: 1.5.0, symbols, invalid, error, broken, filled</remarks>
+	/// <release>1.5</release>
+	ExclamationMarkCircleFilled = 59459,
+
 	/// <summary>Exclamation Mark Circle</summary>
 	/// <remarks>Category: Symbols<br/>
 	/// Alias: 1.5.0, symbols, invalid, error, broken</remarks>
 	/// <release>1.5</release>
 	ExclamationMarkCircle = 59460,
+
+	/// <summary>Exclamation Mark Triangle (Filled)</summary>
+	/// <remarks>Category: Symbols<br/>
+	/// Alias: 1.5.0, symbols, warning, alert, filled</remarks>
+	/// <release>1.5</release>
+	ExclamationMarkTriangleFilled = 59461,
 
 	/// <summary>Exclamation Mark Triangle</summary>
 	/// <remarks>Category: Symbols<br/>
@@ -2180,6 +2252,12 @@ public enum CalciteIcon : ushort
 	/// <release>3.17.0</release>
 	Fingerprint = 59508,
 
+	/// <summary>Flag (Filled)</summary>
+	/// <remarks>Category: Objects<br/>
+	/// Alias: 3.29.1, objects, signal, flag, sign, important, warning, alert, caution, filled</remarks>
+	/// <release>3.29.1</release>
+	FlagFilled = 59509,
+
 	/// <summary>Flag</summary>
 	/// <remarks>Category: Objects<br/>
 	/// Alias: 3.29.1, objects, signal, flag, sign, important, warning, alert, caution</remarks>
@@ -2378,6 +2456,12 @@ public enum CalciteIcon : ushort
 	/// <release>3.16.6</release>
 	FormFieldOff = 59542,
 
+	/// <summary>Forward (Filled)</summary>
+	/// <remarks>Category: Media<br/>
+	/// Alias: 1.5.0, media, filled</remarks>
+	/// <release>1.5</release>
+	ForwardFilled = 59543,
+
 	/// <summary>Forward</summary>
 	/// <remarks>Category: Media<br/>
 	/// Alias: 1.5.0, media</remarks>
@@ -2503,6 +2587,12 @@ public enum CalciteIcon : ushort
 	/// Alias: 1.5.0, gis, locate, current location, tracking</remarks>
 	/// <release>1.5</release>
 	GpsOff = 59564,
+
+	/// <summary>Gps On (Filled)</summary>
+	/// <remarks>Category: GIS<br/>
+	/// Alias: 1.5.0, gis, locate, current location, tracking, filled</remarks>
+	/// <release>1.5</release>
+	GpsOnFilled = 59565,
 
 	/// <summary>Gps On</summary>
 	/// <remarks>Category: GIS<br/>
@@ -2701,6 +2791,12 @@ public enum CalciteIcon : ushort
 	/// Alias: 1.5.0, objects, headphones, customer, service, representative, support</remarks>
 	/// <release>1.5</release>
 	Headset = 59598,
+
+	/// <summary>Heart (Filled)</summary>
+	/// <remarks>Category: Generic<br/>
+	/// Alias: 3.19.9, generic, shape, love, favorite, valentine, gift, like, filled</remarks>
+	/// <release>3.19.9</release>
+	HeartFilled = 59599,
 
 	/// <summary>Heart</summary>
 	/// <remarks>Category: Generic<br/>
@@ -2941,6 +3037,12 @@ public enum CalciteIcon : ushort
 	/// Alias: 1.5.0, generic, shapes, visualization</remarks>
 	/// <release>1.5</release>
 	Infographic = 59639,
+
+	/// <summary>Information (Filled)</summary>
+	/// <remarks>Category: Symbols<br/>
+	/// Alias: 1.5.0, symbols, about, help, tooltip, filled</remarks>
+	/// <release>1.5</release>
+	InformationFilled = 59640,
 
 	/// <summary>Information</summary>
 	/// <remarks>Category: Symbols<br/>
@@ -3524,6 +3626,12 @@ public enum CalciteIcon : ushort
 	/// <release>2.7.0</release>
 	Locator = 59737,
 
+	/// <summary>Lock (Filled)</summary>
+	/// <remarks>Category: Objects<br/>
+	/// Alias: 1.5.0, objects, secure, guarded, permission, security, restricted, privacy, filled</remarks>
+	/// <release>1.5</release>
+	LockFilled = 59738,
+
 	/// <summary>Lock</summary>
 	/// <remarks>Category: Objects<br/>
 	/// Alias: 1.5.0, objects, secure, guarded, permission, security, restricted, privacy</remarks>
@@ -3770,11 +3878,23 @@ public enum CalciteIcon : ushort
 	/// <release>1.5</release>
 	Minus = 59779,
 
+	/// <summary>Minus Circle (Filled)</summary>
+	/// <remarks>Category: Symbols<br/>
+	/// Alias: 3.24.2, symbols, stop, delete, remove, restricted, subtract, filled</remarks>
+	/// <release>3.24.2</release>
+	MinusCircleFilled = 59780,
+
 	/// <summary>Minus Circle</summary>
 	/// <remarks>Category: Symbols<br/>
 	/// Alias: 3.24.2, symbols, stop, delete, remove, restricted, subtract</remarks>
 	/// <release>3.24.2</release>
 	MinusCircle = 59781,
+
+	/// <summary>Minus Square (Filled)</summary>
+	/// <remarks>Category: Symbols<br/>
+	/// Alias: 3.23.6, symbols, hyphen, line, filled, subtract, filled</remarks>
+	/// <release>3.23.6</release>
+	MinusSquareFilled = 59782,
 
 	/// <summary>Minus Square</summary>
 	/// <remarks>Category: Symbols<br/>
@@ -4280,6 +4400,12 @@ public enum CalciteIcon : ushort
 	/// <release>3.28.0</release>
 	PasteWithoutAttribute = 59866,
 
+	/// <summary>Pause (Filled)</summary>
+	/// <remarks>Category: Media<br/>
+	/// Alias: 1.5.0, media, filled</remarks>
+	/// <release>1.5</release>
+	PauseFilled = 59867,
+
 	/// <summary>Pause</summary>
 	/// <remarks>Category: Media<br/>
 	/// Alias: 1.5.0, media</remarks>
@@ -4394,6 +4520,12 @@ public enum CalciteIcon : ushort
 	/// <release>1.5</release>
 	PinPlus = 59886,
 
+	/// <summary>Pin Tear (Filled)</summary>
+	/// <remarks>Category: Generic<br/>
+	/// Alias: 3.16.1, generic, location, map pin, map marker, destination, dropped pin, drop pin, filled</remarks>
+	/// <release>3.16.1</release>
+	PinTearFilled = 59887,
+
 	/// <summary>Pin Tear</summary>
 	/// <remarks>Category: Generic<br/>
 	/// Alias: 3.16.1, generic, location, map pin, map marker, destination, dropped pin, drop pin</remarks>
@@ -4417,6 +4549,12 @@ public enum CalciteIcon : ushort
 	/// Alias: 3.0.0, blueprint, layout, measurements, perimeter, width, height, boundary, interior, scale</remarks>
 	/// <release>3.0.0</release>
 	Plans = 59891,
+
+	/// <summary>Play (Filled)</summary>
+	/// <remarks>Category: Media<br/>
+	/// Alias: 1.5.0, media, run, test, filled</remarks>
+	/// <release>1.5</release>
+	PlayFilled = 59892,
 
 	/// <summary>Play</summary>
 	/// <remarks>Category: Media<br/>
@@ -4610,6 +4748,12 @@ public enum CalciteIcon : ushort
 	/// <release>3.25.8</release>
 	Query = 59924,
 
+	/// <summary>Question (Filled)</summary>
+	/// <remarks>Category: Symbols<br/>
+	/// Alias: 1.5.0, symbols, faq, unknown, help, hint, filled</remarks>
+	/// <release>1.5</release>
+	QuestionFilled = 59925,
+
 	/// <summary>Question</summary>
 	/// <remarks>Category: Symbols<br/>
 	/// Alias: 1.5.0, symbols, faq, unknown, help, hint</remarks>
@@ -4627,6 +4771,9 @@ public enum CalciteIcon : ushort
 	/// Alias: 3.3.0, quotation marks, reference</remarks>
 	/// <release>3.3.0</release>
 	Quote = 59928,
+
+	/// <summary>Radial Tree Link Chart Yayout</summary>
+	RadialTreeLinkChartYayout = 59929,
 
 	/// <summary>Rain</summary>
 	/// <remarks>Category: Weather<br/>
@@ -4825,6 +4972,12 @@ public enum CalciteIcon : ushort
 	/// Alias: gis, 3.17.1, geoai, train</remarks>
 	/// <release>3.17.1</release>
 	Retrain = 59962,
+
+	/// <summary>Reverse (Filled)</summary>
+	/// <remarks>Category: Media<br/>
+	/// Alias: 1.5.0, media, filled</remarks>
+	/// <release>1.5</release>
+	ReverseFilled = 59963,
 
 	/// <summary>Reverse</summary>
 	/// <remarks>Category: Media<br/>
@@ -5564,6 +5717,12 @@ public enum CalciteIcon : ushort
 	/// <release>3.25.2</release>
 	SplitUnits = 60086,
 
+	/// <summary>Square (Filled)</summary>
+	/// <remarks>Category: Generic<br/>
+	/// Alias: 1.5.0, generic, shapes, box, container, filled</remarks>
+	/// <release>1.5</release>
+	SquareFilled = 60087,
+
 	/// <summary>Square</summary>
 	/// <remarks>Category: Generic<br/>
 	/// Alias: 1.5.0, generic, shapes, box, container</remarks>
@@ -5606,6 +5765,12 @@ public enum CalciteIcon : ushort
 	/// <release>3.22.1</release>
 	StairsUp = 60094,
 
+	/// <summary>Star (Filled)</summary>
+	/// <remarks>Category: Symbols<br/>
+	/// Alias: 3.3.0, symbols, favorite, rate, rating, filled</remarks>
+	/// <release>3.3.0</release>
+	StarFilled = 60095,
+
 	/// <summary>Star</summary>
 	/// <remarks>Category: Symbols<br/>
 	/// Alias: 3.3.0, symbols, favorite, rate, rating</remarks>
@@ -5623,6 +5788,12 @@ public enum CalciteIcon : ushort
 	/// Alias: 3.25.2, symbols, online model builder, stopping, slow, stopped, hold</remarks>
 	/// <release>3.25.2</release>
 	Stop = 60098,
+
+	/// <summary>Stop Square (Filled)</summary>
+	/// <remarks>Category: Media<br/>
+	/// Alias: 3.24.1, media, cube, stop, halt, end, finish, filled</remarks>
+	/// <release>3.24.1</release>
+	StopSquareFilled = 60099,
 
 	/// <summary>Stop Square</summary>
 	/// <remarks>Category: Media<br/>
@@ -5990,6 +6161,12 @@ public enum CalciteIcon : ushort
 	/// <release>3.29.4</release>
 	TracePathComplete = 60160,
 
+	/// <summary>Transcript (Filled)</summary>
+	/// <remarks>Category: Media<br/>
+	/// Alias: 3.29.3, media, captions, text, video, display, speech, filled</remarks>
+	/// <release>3.29.3</release>
+	TranscriptFilled = 60161,
+
 	/// <summary>Transcript</summary>
 	/// <remarks>Category: Media<br/>
 	/// Alias: 3.29.3, media, captions, text, video, display, speech</remarks>
@@ -6356,6 +6533,9 @@ public enum CalciteIcon : ushort
 	/// <release>1.5</release>
 	Web = 60222,
 
+	/// <summary>Web Adaptor</summary>
+	WebAdaptor = 60223,
+
 	/// <summary>Webhook</summary>
 	/// <remarks>Category: Symbols<br/>
 	/// Alias: 3.14.0, symbols, web hook, event, information, manage, create, http request, payload, application, push</remarks>
@@ -6428,11 +6608,23 @@ public enum CalciteIcon : ushort
 	/// <release>3.1.0</release>
 	XBar = 60235,
 
+	/// <summary>X Circle (Filled)</summary>
+	/// <remarks>Category: Symbols<br/>
+	/// Alias: 3.8.1, symbols, delete, remove, close, filled</remarks>
+	/// <release>3.8.1</release>
+	XCircleFilled = 60236,
+
 	/// <summary>X Circle</summary>
 	/// <remarks>Category: Symbols<br/>
 	/// Alias: 3.8.1, symbols, delete, remove, close</remarks>
 	/// <release>3.8.1</release>
 	XCircle = 60237,
+
+	/// <summary>X Octagon (Filled)</summary>
+	/// <remarks>Category: Symbols<br/>
+	/// Alias: 3.11.0, x octagon, invalid, error, broken, critical, denied, restricted, filled</remarks>
+	/// <release>3.11.0</release>
+	XOctagonFilled = 60238,
 
 	/// <summary>X Octagon</summary>
 	/// <remarks>Category: Symbols<br/>

--- a/GeneratedResources/WinUI/CalciteIcon.cs
+++ b/GeneratedResources/WinUI/CalciteIcon.cs
@@ -4772,9 +4772,6 @@ public enum CalciteIcon : ushort
 	/// <release>3.3.0</release>
 	Quote = 59928,
 
-	/// <summary>Radial Tree Link Chart Yayout</summary>
-	RadialTreeLinkChartYayout = 59929,
-
 	/// <summary>Rain</summary>
 	/// <remarks>Category: Weather<br/>
 	/// Alias: 3.17.6, generic, clouds, weather, sky, forecast, temperature, environment, nature, precipitation, wind, stormy, clouds</remarks>

--- a/GeneratedResources/WinUI/IconHelpers.cs
+++ b/GeneratedResources/WinUI/IconHelpers.cs
@@ -1,4 +1,4 @@
-// COPYRIGHT © 2025 Esri
+// COPYRIGHT ï¿½ 2025 Esri
 // All rights reserved under the copyright laws of the United States and applicable international laws, treaties, and conventions.
 // This material is licensed for use under the Esri Master License Agreement (MLA), and is bound by the terms of that agreement.
 // You may redistribute and use this code without modification, provided you adhere to the terms of the MLA and include this copyright notice.
@@ -48,6 +48,7 @@ internal static class IconHelpers
 			case CalciteIcon.AddText: return "AddText";
 			case CalciteIcon.AddToModel: return "AddToModel";
 			case CalciteIcon.AddressBook: return "AddressBook";
+			case CalciteIcon.AlertOffCircleFilled: return "AlertOffCircleFilled";
 			case CalciteIcon.AllServers: return "AllServers";
 			case CalciteIcon.Altitude: return "Altitude";
 			case CalciteIcon.Analysis: return "Analysis";
@@ -102,7 +103,9 @@ internal static class IconHelpers
 			case CalciteIcon.Beaker: return "Beaker";
 			case CalciteIcon.BearLeft: return "BearLeft";
 			case CalciteIcon.BearRight: return "BearRight";
+			case CalciteIcon.BeginningFilled: return "BeginningFilled";
 			case CalciteIcon.Beginning: return "Beginning";
+			case CalciteIcon.BellFilled: return "BellFilled";
 			case CalciteIcon.Bell: return "Bell";
 			case CalciteIcon.BellOff: return "BellOff";
 			case CalciteIcon.Beta: return "Beta";
@@ -161,10 +164,12 @@ internal static class IconHelpers
 			case CalciteIcon.ChartGear: return "ChartGear";
 			case CalciteIcon.ChartMagnifyingGlass: return "ChartMagnifyingGlass";
 			case CalciteIcon.Check: return "Check";
+			case CalciteIcon.CheckCircleFilled: return "CheckCircleFilled";
 			case CalciteIcon.CheckCircle: return "CheckCircle";
 			case CalciteIcon.CheckExtent: return "CheckExtent";
 			case CalciteIcon.CheckLayer: return "CheckLayer";
 			case CalciteIcon.CheckShield: return "CheckShield";
+			case CalciteIcon.CheckSquareFilled: return "CheckSquareFilled";
 			case CalciteIcon.CheckSquare: return "CheckSquare";
 			case CalciteIcon.ChevronDown: return "ChevronDown";
 			case CalciteIcon.ChevronDownLeft: return "ChevronDownLeft";
@@ -181,12 +186,15 @@ internal static class IconHelpers
 			case CalciteIcon.ChevronsRight: return "ChevronsRight";
 			case CalciteIcon.ChevronsUp: return "ChevronsUp";
 			case CalciteIcon.ChordDiagram: return "ChordDiagram";
+			case CalciteIcon.CircleFilled: return "CircleFilled";
 			case CalciteIcon.Circle: return "Circle";
 			case CalciteIcon.CircleDisallowed: return "CircleDisallowed";
 			case CalciteIcon.CircleInsetLarge: return "CircleInsetLarge";
 			case CalciteIcon.CircleInsetMedium: return "CircleInsetMedium";
 			case CalciteIcon.CircleInsetSmall: return "CircleInsetSmall";
+			case CalciteIcon.CirclePauseFilled: return "CirclePauseFilled";
 			case CalciteIcon.CirclePause: return "CirclePause";
+			case CalciteIcon.CircleStopFilled: return "CircleStopFilled";
 			case CalciteIcon.CircleStop: return "CircleStop";
 			case CalciteIcon.ClassifyObjects: return "ClassifyObjects";
 			case CalciteIcon.ClearSelection: return "ClearSelection";
@@ -196,6 +204,7 @@ internal static class IconHelpers
 			case CalciteIcon.ClockDown: return "ClockDown";
 			case CalciteIcon.ClockForward: return "ClockForward";
 			case CalciteIcon.ClockUp: return "ClockUp";
+			case CalciteIcon.ClosedCaptionFilled: return "ClosedCaptionFilled";
 			case CalciteIcon.ClosedCaption: return "ClosedCaption";
 			case CalciteIcon.Cloud: return "Cloud";
 			case CalciteIcon.CloudData: return "CloudData";
@@ -322,6 +331,7 @@ internal static class IconHelpers
 			case CalciteIcon.EmbeddedLiveContent: return "EmbeddedLiveContent";
 			case CalciteIcon.EmployeeId: return "EmployeeId";
 			case CalciteIcon.EnableDisableFeatureSelection: return "EnableDisableFeatureSelection";
+			case CalciteIcon.EndFilled: return "EndFilled";
 			case CalciteIcon.End: return "End";
 			case CalciteIcon.Envelope: return "Envelope";
 			case CalciteIcon.Erase: return "Erase";
@@ -329,7 +339,9 @@ internal static class IconHelpers
 			case CalciteIcon.EscalatorDown: return "EscalatorDown";
 			case CalciteIcon.EscalatorUp: return "EscalatorUp";
 			case CalciteIcon.Event: return "Event";
+			case CalciteIcon.ExclamationMarkCircleFilled: return "ExclamationMarkCircleFilled";
 			case CalciteIcon.ExclamationMarkCircle: return "ExclamationMarkCircle";
+			case CalciteIcon.ExclamationMarkTriangleFilled: return "ExclamationMarkTriangleFilled";
 			case CalciteIcon.ExclamationMarkTriangle: return "ExclamationMarkTriangle";
 			case CalciteIcon.ExclamationPointFilled: return "ExclamationPointFilled";
 			case CalciteIcon.ExclamationPoint: return "ExclamationPoint";
@@ -377,6 +389,7 @@ internal static class IconHelpers
 			case CalciteIcon.Filter: return "Filter";
 			case CalciteIcon.FilterExpand: return "FilterExpand";
 			case CalciteIcon.Fingerprint: return "Fingerprint";
+			case CalciteIcon.FlagFilled: return "FlagFilled";
 			case CalciteIcon.Flag: return "Flag";
 			case CalciteIcon.FlagSlash: return "FlagSlash";
 			case CalciteIcon.Flash: return "Flash";
@@ -410,6 +423,7 @@ internal static class IconHelpers
 			case CalciteIcon.FormField: return "FormField";
 			case CalciteIcon.FormFieldMultiline: return "FormFieldMultiline";
 			case CalciteIcon.FormFieldOff: return "FormFieldOff";
+			case CalciteIcon.ForwardFilled: return "ForwardFilled";
 			case CalciteIcon.Forward: return "Forward";
 			case CalciteIcon.FrameExport: return "FrameExport";
 			case CalciteIcon.Freehand: return "Freehand";
@@ -431,6 +445,7 @@ internal static class IconHelpers
 			case CalciteIcon.GisServer: return "GisServer";
 			case CalciteIcon.Globe: return "Globe";
 			case CalciteIcon.GpsOff: return "GpsOff";
+			case CalciteIcon.GpsOnFilled: return "GpsOnFilled";
 			case CalciteIcon.GpsOn: return "GpsOn";
 			case CalciteIcon.GraphAxis: return "GraphAxis";
 			case CalciteIcon.GraphBar100Stacked: return "GraphBar100Stacked";
@@ -464,6 +479,7 @@ internal static class IconHelpers
 			case CalciteIcon.HeadingLayout: return "HeadingLayout";
 			case CalciteIcon.HeadingRtl: return "HeadingRtl";
 			case CalciteIcon.Headset: return "Headset";
+			case CalciteIcon.HeartFilled: return "HeartFilled";
 			case CalciteIcon.Heart: return "Heart";
 			case CalciteIcon.HeatChart: return "HeatChart";
 			case CalciteIcon.HeavyRain: return "HeavyRain";
@@ -504,6 +520,7 @@ internal static class IconHelpers
 			case CalciteIcon.IncreaseLinkChartSymbolSize: return "IncreaseLinkChartSymbolSize";
 			case CalciteIcon.Indicator: return "Indicator";
 			case CalciteIcon.Infographic: return "Infographic";
+			case CalciteIcon.InformationFilled: return "InformationFilled";
 			case CalciteIcon.Information: return "Information";
 			case CalciteIcon.InformationLetter: return "InformationLetter";
 			case CalciteIcon.Initiative: return "Initiative";
@@ -601,6 +618,7 @@ internal static class IconHelpers
 			case CalciteIcon.LocationSharing: return "LocationSharing";
 			case CalciteIcon.LocationSharingOff: return "LocationSharingOff";
 			case CalciteIcon.Locator: return "Locator";
+			case CalciteIcon.LockFilled: return "LockFilled";
 			case CalciteIcon.Lock: return "Lock";
 			case CalciteIcon.LtrElementsAlign: return "LtrElementsAlign";
 			case CalciteIcon.LtrParagraphAlign: return "LtrParagraphAlign";
@@ -642,7 +660,9 @@ internal static class IconHelpers
 			case CalciteIcon.Minimum: return "Minimum";
 			case CalciteIcon.MinimumGraph: return "MinimumGraph";
 			case CalciteIcon.Minus: return "Minus";
+			case CalciteIcon.MinusCircleFilled: return "MinusCircleFilled";
 			case CalciteIcon.MinusCircle: return "MinusCircle";
+			case CalciteIcon.MinusSquareFilled: return "MinusSquareFilled";
 			case CalciteIcon.MinusSquare: return "MinusSquare";
 			case CalciteIcon.MiscellaneousCollection: return "MiscellaneousCollection";
 			case CalciteIcon.MissionServer: return "MissionServer";
@@ -727,6 +747,7 @@ internal static class IconHelpers
 			case CalciteIcon.Paste: return "Paste";
 			case CalciteIcon.PasteWithAttribute: return "PasteWithAttribute";
 			case CalciteIcon.PasteWithoutAttribute: return "PasteWithoutAttribute";
+			case CalciteIcon.PauseFilled: return "PauseFilled";
 			case CalciteIcon.Pause: return "Pause";
 			case CalciteIcon.Pen: return "Pen";
 			case CalciteIcon.PenMark: return "PenMark";
@@ -746,10 +767,12 @@ internal static class IconHelpers
 			case CalciteIcon.PieChart: return "PieChart";
 			case CalciteIcon.Pin: return "Pin";
 			case CalciteIcon.PinPlus: return "PinPlus";
+			case CalciteIcon.PinTearFilled: return "PinTearFilled";
 			case CalciteIcon.PinTear: return "PinTear";
 			case CalciteIcon.Pins: return "Pins";
 			case CalciteIcon.Plane: return "Plane";
 			case CalciteIcon.Plans: return "Plans";
+			case CalciteIcon.PlayFilled: return "PlayFilled";
 			case CalciteIcon.Play: return "Play";
 			case CalciteIcon.Plus: return "Plus";
 			case CalciteIcon.PlusCircle: return "PlusCircle";
@@ -782,9 +805,11 @@ internal static class IconHelpers
 			case CalciteIcon.QrCode: return "QrCode";
 			case CalciteIcon.QtCode: return "QtCode";
 			case CalciteIcon.Query: return "Query";
+			case CalciteIcon.QuestionFilled: return "QuestionFilled";
 			case CalciteIcon.Question: return "Question";
 			case CalciteIcon.QuestionMark: return "QuestionMark";
 			case CalciteIcon.Quote: return "Quote";
+			case CalciteIcon.RadialTreeLinkChartYayout: return "RadialTreeLinkChartYayout";
 			case CalciteIcon.Rain: return "Rain";
 			case CalciteIcon.RainSnow: return "RainSnow";
 			case CalciteIcon.RainThunder: return "RainThunder";
@@ -818,6 +843,7 @@ internal static class IconHelpers
 			case CalciteIcon.ReshapeTool: return "ReshapeTool";
 			case CalciteIcon.ResizeArea: return "ResizeArea";
 			case CalciteIcon.Retrain: return "Retrain";
+			case CalciteIcon.ReverseFilled: return "ReverseFilled";
 			case CalciteIcon.Reverse: return "Reverse";
 			case CalciteIcon.Rfid: return "Rfid";
 			case CalciteIcon.Rhombus: return "Rhombus";
@@ -941,6 +967,7 @@ internal static class IconHelpers
 			case CalciteIcon.SplitFeatures: return "SplitFeatures";
 			case CalciteIcon.SplitGeometry: return "SplitGeometry";
 			case CalciteIcon.SplitUnits: return "SplitUnits";
+			case CalciteIcon.SquareFilled: return "SquareFilled";
 			case CalciteIcon.Square: return "Square";
 			case CalciteIcon.SquareInsetLarge: return "SquareInsetLarge";
 			case CalciteIcon.SquareInsetMedium: return "SquareInsetMedium";
@@ -948,9 +975,11 @@ internal static class IconHelpers
 			case CalciteIcon.Stairs: return "Stairs";
 			case CalciteIcon.StairsDown: return "StairsDown";
 			case CalciteIcon.StairsUp: return "StairsUp";
+			case CalciteIcon.StarFilled: return "StarFilled";
 			case CalciteIcon.Star: return "Star";
 			case CalciteIcon.StarCircle: return "StarCircle";
 			case CalciteIcon.Stop: return "Stop";
+			case CalciteIcon.StopSquareFilled: return "StopSquareFilled";
 			case CalciteIcon.StopSquare: return "StopSquare";
 			case CalciteIcon.Storage: return "Storage";
 			case CalciteIcon.StoredAsNewQuery: return "StoredAsNewQuery";
@@ -1012,6 +1041,7 @@ internal static class IconHelpers
 			case CalciteIcon.Trace: return "Trace";
 			case CalciteIcon.TracePath: return "TracePath";
 			case CalciteIcon.TracePathComplete: return "TracePathComplete";
+			case CalciteIcon.TranscriptFilled: return "TranscriptFilled";
 			case CalciteIcon.Transcript: return "Transcript";
 			case CalciteIcon.TransverseHexagon: return "TransverseHexagon";
 			case CalciteIcon.Trash: return "Trash";
@@ -1073,6 +1103,7 @@ internal static class IconHelpers
 			case CalciteIcon.WalkingDistance: return "WalkingDistance";
 			case CalciteIcon.WalkingTime: return "WalkingTime";
 			case CalciteIcon.Web: return "Web";
+			case CalciteIcon.WebAdaptor: return "WebAdaptor";
 			case CalciteIcon.Webhook: return "Webhook";
 			case CalciteIcon.Wheelchair: return "Wheelchair";
 			case CalciteIcon.WidgetsGroup: return "WidgetsGroup";
@@ -1085,7 +1116,9 @@ internal static class IconHelpers
 			case CalciteIcon.X: return "X";
 			case CalciteIcon.XAxisGuide: return "XAxisGuide";
 			case CalciteIcon.XBar: return "XBar";
+			case CalciteIcon.XCircleFilled: return "XCircleFilled";
 			case CalciteIcon.XCircle: return "XCircle";
+			case CalciteIcon.XOctagonFilled: return "XOctagonFilled";
 			case CalciteIcon.XOctagon: return "XOctagon";
 			case CalciteIcon.YAxisGuide: return "YAxisGuide";
 			case CalciteIcon.ZoomInFixed: return "ZoomInFixed";

--- a/GeneratedResources/WinUI/IconHelpers.cs
+++ b/GeneratedResources/WinUI/IconHelpers.cs
@@ -809,7 +809,6 @@ internal static class IconHelpers
 			case CalciteIcon.Question: return "Question";
 			case CalciteIcon.QuestionMark: return "QuestionMark";
 			case CalciteIcon.Quote: return "Quote";
-			case CalciteIcon.RadialTreeLinkChartYayout: return "RadialTreeLinkChartYayout";
 			case CalciteIcon.Rain: return "Rain";
 			case CalciteIcon.RainSnow: return "RainSnow";
 			case CalciteIcon.RainThunder: return "RainThunder";

--- a/GeneratedResources/WinUI/Icons/Glyphs.xaml
+++ b/GeneratedResources/WinUI/Icons/Glyphs.xaml
@@ -851,7 +851,6 @@
     <x:String x:Key="CalciteUIIcons_Glyph_QuestionMark">&#xea17;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_Quote">&#xea18;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_RadialTreeLinkChartLayout">&#xeb65;</x:String> 
-    <x:String x:Key="CalciteUIIcons_Glyph_RadialTreeLinkChartYayout">&#xea19;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_Rain">&#xea1a;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_RainSnow">&#xea1b;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_RainThunder">&#xea1c;</x:String> 

--- a/GeneratedResources/WinUI/Icons/Glyphs.xaml
+++ b/GeneratedResources/WinUI/Icons/Glyphs.xaml
@@ -30,6 +30,7 @@
     <x:String x:Key="CalciteUIIcons_Glyph_AddText">&#xe71d;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_AddToModel">&#xe71e;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_AddressBook">&#xe71f;</x:String> 
+    <x:String x:Key="CalciteUIIcons_Glyph_AlertOffCircleFilled">&#xe720;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_AllServers">&#xe721;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_Altitude">&#xe722;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_Analysis">&#xe723;</x:String> 
@@ -87,7 +88,9 @@
     <x:String x:Key="CalciteUIIcons_Glyph_BearLeft">&#xe755;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_BearRight">&#xe756;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_Beginning">&#xe758;</x:String> 
+    <x:String x:Key="CalciteUIIcons_Glyph_BeginningFilled">&#xe757;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_Bell">&#xe75a;</x:String> 
+    <x:String x:Key="CalciteUIIcons_Glyph_BellFilled">&#xe759;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_BellOff">&#xe75b;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_Beta">&#xe75c;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_Biking">&#xe75d;</x:String> 
@@ -152,10 +155,12 @@
     <x:String x:Key="CalciteUIIcons_Glyph_ChartMagnifyingGlass">&#xe792;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_Check">&#xe793;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_CheckCircle">&#xe795;</x:String> 
+    <x:String x:Key="CalciteUIIcons_Glyph_CheckCircleFilled">&#xe794;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_CheckExtent">&#xe796;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_CheckLayer">&#xe797;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_CheckShield">&#xe798;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_CheckSquare">&#xe79a;</x:String> 
+    <x:String x:Key="CalciteUIIcons_Glyph_CheckSquareFilled">&#xe799;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_ChevronDown">&#xe79b;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_ChevronDownLeft">&#xe79c;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_ChevronDownRight">&#xe79d;</x:String> 
@@ -172,13 +177,16 @@
     <x:String x:Key="CalciteUIIcons_Glyph_ChevronsUp">&#xe7a8;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_ChordDiagram">&#xe7a9;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_Circle">&#xe7ab;</x:String> 
+    <x:String x:Key="CalciteUIIcons_Glyph_CircleFilled">&#xe7aa;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_CircleAreaHashFilled">&#xeb74;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_CircleDisallowed">&#xe7ac;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_CircleInsetLarge">&#xe7ad;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_CircleInsetMedium">&#xe7ae;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_CircleInsetSmall">&#xe7af;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_CirclePause">&#xe7b1;</x:String> 
+    <x:String x:Key="CalciteUIIcons_Glyph_CirclePauseFilled">&#xe7b0;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_CircleStop">&#xe7b3;</x:String> 
+    <x:String x:Key="CalciteUIIcons_Glyph_CircleStopFilled">&#xe7b2;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_ClassifyObjects">&#xe7b4;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_ClearSelection">&#xe7b5;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_Clipboard">&#xe7b6;</x:String> 
@@ -188,6 +196,7 @@
     <x:String x:Key="CalciteUIIcons_Glyph_ClockForward">&#xe7ba;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_ClockUp">&#xe7bb;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_ClosedCaption">&#xe7bd;</x:String> 
+    <x:String x:Key="CalciteUIIcons_Glyph_ClosedCaptionFilled">&#xe7bc;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_Cloud">&#xe7be;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_CloudData">&#xe7bf;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_CloudServer">&#xe7c0;</x:String> 
@@ -328,6 +337,7 @@
     <x:String x:Key="CalciteUIIcons_Glyph_EmployeeId">&#xe839;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_EnableDisableFeatureSelection">&#xe83a;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_End">&#xe83c;</x:String> 
+    <x:String x:Key="CalciteUIIcons_Glyph_EndFilled">&#xe83b;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_Envelope">&#xe83d;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_Erase">&#xe83e;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_Escalator">&#xe83f;</x:String> 
@@ -335,7 +345,9 @@
     <x:String x:Key="CalciteUIIcons_Glyph_EscalatorUp">&#xe841;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_Event">&#xe842;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_ExclamationMarkCircle">&#xe844;</x:String> 
+    <x:String x:Key="CalciteUIIcons_Glyph_ExclamationMarkCircleFilled">&#xe843;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_ExclamationMarkTriangle">&#xe846;</x:String> 
+    <x:String x:Key="CalciteUIIcons_Glyph_ExclamationMarkTriangleFilled">&#xe845;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_ExclamationPoint">&#xe848;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_ExclamationPointFilled">&#xe847;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_ExitHighwayLeft">&#xe849;</x:String> 
@@ -385,6 +397,7 @@
     <x:String x:Key="CalciteUIIcons_Glyph_FindAddPath">&#xf118;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_Fingerprint">&#xe874;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_Flag">&#xe876;</x:String> 
+    <x:String x:Key="CalciteUIIcons_Glyph_FlagFilled">&#xe875;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_FlagSlash">&#xe877;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_Flash">&#xe878;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_Flip">&#xe879;</x:String> 
@@ -418,6 +431,7 @@
     <x:String x:Key="CalciteUIIcons_Glyph_FormFieldMultiline">&#xe895;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_FormFieldOff">&#xe896;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_Forward">&#xe898;</x:String> 
+    <x:String x:Key="CalciteUIIcons_Glyph_ForwardFilled">&#xe897;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_FourTimes">&#xe708;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_FrameExport">&#xe899;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_Freehand">&#xe89a;</x:String> 
@@ -441,6 +455,7 @@
     <x:String x:Key="CalciteUIIcons_Glyph_GovernmentBuilding">&#xeb76;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_GpsOff">&#xe8ac;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_GpsOn">&#xe8ae;</x:String> 
+    <x:String x:Key="CalciteUIIcons_Glyph_GpsOnFilled">&#xe8ad;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_GraphAxis">&#xe8af;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_GraphBar">&#xe8b1;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_GraphBar100Stacked">&#xe8b0;</x:String> 
@@ -476,6 +491,7 @@
     <x:String x:Key="CalciteUIIcons_Glyph_HeadingRtl">&#xe8cd;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_Headset">&#xe8ce;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_Heart">&#xe8d0;</x:String> 
+    <x:String x:Key="CalciteUIIcons_Glyph_HeartFilled">&#xe8cf;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_HeatChart">&#xe8d1;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_HeavyRain">&#xe8d2;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_HeavySnow">&#xe8d3;</x:String> 
@@ -519,6 +535,7 @@
     <x:String x:Key="CalciteUIIcons_Glyph_Indicator">&#xe8f6;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_Infographic">&#xe8f7;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_Information">&#xe8f9;</x:String> 
+    <x:String x:Key="CalciteUIIcons_Glyph_InformationFilled">&#xe8f8;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_InformationLetter">&#xe8fa;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_Initiative">&#xe8fb;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_InitiativeTemplate">&#xeb5f;</x:String> 
@@ -628,6 +645,7 @@
     <x:String x:Key="CalciteUIIcons_Glyph_LocationSharingOff">&#xe958;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_Locator">&#xe959;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_Lock">&#xe95b;</x:String> 
+    <x:String x:Key="CalciteUIIcons_Glyph_LockFilled">&#xe95a;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_LtrElementsAlign">&#xe95c;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_LtrParagraphAlign">&#xe95d;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_MagnifyingGlass">&#xe95e;</x:String> 
@@ -670,7 +688,9 @@
     <x:String x:Key="CalciteUIIcons_Glyph_MinimumGraph">&#xe982;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_Minus">&#xe983;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_MinusCircle">&#xe985;</x:String> 
+    <x:String x:Key="CalciteUIIcons_Glyph_MinusCircleFilled">&#xe984;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_MinusSquare">&#xe987;</x:String> 
+    <x:String x:Key="CalciteUIIcons_Glyph_MinusSquareFilled">&#xe986;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_MiscellaneousCollection">&#xe988;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_MissionServer">&#xe989;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_Mobile">&#xe98a;</x:String> 
@@ -765,6 +785,7 @@
     <x:String x:Key="CalciteUIIcons_Glyph_PasteWithAttribute">&#xe9d9;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_PasteWithoutAttribute">&#xe9da;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_Pause">&#xe9dc;</x:String> 
+    <x:String x:Key="CalciteUIIcons_Glyph_PauseFilled">&#xe9db;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_Pen">&#xe9dd;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_PenMark">&#xe9de;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_PenMarkPlus">&#xe9df;</x:String> 
@@ -786,10 +807,12 @@
     <x:String x:Key="CalciteUIIcons_Glyph_Pin">&#xe9ed;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_PinPlus">&#xe9ee;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_PinTear">&#xe9f0;</x:String> 
+    <x:String x:Key="CalciteUIIcons_Glyph_PinTearFilled">&#xe9ef;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_Pins">&#xe9f1;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_Plane">&#xe9f2;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_Plans">&#xe9f3;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_Play">&#xe9f5;</x:String> 
+    <x:String x:Key="CalciteUIIcons_Glyph_PlayFilled">&#xe9f4;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_PlugConnection">&#xf109;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_Plus">&#xe9f6;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_PlusCircle">&#xe9f7;</x:String> 
@@ -824,9 +847,11 @@
     <x:String x:Key="CalciteUIIcons_Glyph_QtCode">&#xea13;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_Query">&#xea14;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_Question">&#xea16;</x:String> 
+    <x:String x:Key="CalciteUIIcons_Glyph_QuestionFilled">&#xea15;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_QuestionMark">&#xea17;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_Quote">&#xea18;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_RadialTreeLinkChartLayout">&#xeb65;</x:String> 
+    <x:String x:Key="CalciteUIIcons_Glyph_RadialTreeLinkChartYayout">&#xea19;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_Rain">&#xea1a;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_RainSnow">&#xea1b;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_RainThunder">&#xea1c;</x:String> 
@@ -862,6 +887,7 @@
     <x:String x:Key="CalciteUIIcons_Glyph_ResizeArea">&#xea39;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_Retrain">&#xea3a;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_Reverse">&#xea3c;</x:String> 
+    <x:String x:Key="CalciteUIIcons_Glyph_ReverseFilled">&#xea3b;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_Rfid">&#xea3d;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_Rhombus">&#xea3e;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_Ribbon">&#xea3f;</x:String> 
@@ -996,6 +1022,7 @@
     <x:String x:Key="CalciteUIIcons_Glyph_SplitGeometry">&#xeab5;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_SplitUnits">&#xeab6;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_Square">&#xeab8;</x:String> 
+    <x:String x:Key="CalciteUIIcons_Glyph_SquareFilled">&#xeab7;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_SquareBracketsX">&#xeb69;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_SquareHashFilled">&#xeb80;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_SquareHashFilledArea">&#xeb7f;</x:String> 
@@ -1006,9 +1033,11 @@
     <x:String x:Key="CalciteUIIcons_Glyph_StairsDown">&#xeabd;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_StairsUp">&#xeabe;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_Star">&#xeac0;</x:String> 
+    <x:String x:Key="CalciteUIIcons_Glyph_StarFilled">&#xeabf;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_StarCircle">&#xeac1;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_Stop">&#xeac2;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_StopSquare">&#xeac4;</x:String> 
+    <x:String x:Key="CalciteUIIcons_Glyph_StopSquareFilled">&#xeac3;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_Storage">&#xeac5;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_StoredAsNewQuery">&#xeac6;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_StoredQuery">&#xeac7;</x:String> 
@@ -1070,6 +1099,7 @@
     <x:String x:Key="CalciteUIIcons_Glyph_TracePath">&#xeaff;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_TracePathComplete">&#xeb00;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_Transcript">&#xeb02;</x:String> 
+    <x:String x:Key="CalciteUIIcons_Glyph_TranscriptFilled">&#xeb01;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_TransverseHexagon">&#xeb03;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_Trash">&#xeb04;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_Tree">&#xeb81;</x:String> 
@@ -1138,6 +1168,7 @@
     <x:String x:Key="CalciteUIIcons_Glyph_WaterDrop">&#xeb82;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_Web">&#xeb3e;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_WebAdapter">&#xeb6b;</x:String> 
+    <x:String x:Key="CalciteUIIcons_Glyph_WebAdaptor">&#xeb3f;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_Webhook">&#xeb40;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_Wheelchair">&#xeb41;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_WhiteCursorSelection">&#xeb83;</x:String> 
@@ -1153,7 +1184,9 @@
     <x:String x:Key="CalciteUIIcons_Glyph_XAxisGuide">&#xeb4a;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_XBar">&#xeb4b;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_XCircle">&#xeb4d;</x:String> 
+    <x:String x:Key="CalciteUIIcons_Glyph_XCircleFilled">&#xeb4c;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_XOctagon">&#xeb4f;</x:String> 
+    <x:String x:Key="CalciteUIIcons_Glyph_XOctagonFilled">&#xeb4e;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_YAxisGuide">&#xeb50;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_ZoningParameter">&#xeb6c;</x:String> 
     <x:String x:Key="CalciteUIIcons_Glyph_ZoomInFixed">&#xeb51;</x:String> 

--- a/Tools/ResourceGenerator/IconEntry.cs
+++ b/Tools/ResourceGenerator/IconEntry.cs
@@ -55,10 +55,29 @@ namespace IconXamlGenerator
                 var name = key;
                 var glyph = (ushort)item.Value;
                 var entry = iconEntries.FirstOrDefault(f => f.Key  == name + (isFilled ? "-f" : ""));
+                if(entry is null && isFilled) // Sometimes the filled version is missing. Find the non-filled version instead and clone it
+                {
+                    var entry2 = iconEntries.FirstOrDefault(f => f.Key == name);
+                    if (entry2 is not null)
+                    {
+                        var filled = new IconEntry()
+                        {
+                            Key = name + "-f",
+                            Alias = entry2.Alias + ", filled",
+                            Category = entry2.Category,
+                            Release = entry2.Release,
+                            MultiPath = entry2.MultiPath,
+                        };
+                        iconEntries.Add(filled);
+                        entry = filled;
+                    }
+                }
                 if(entry is null)
                 {
+                    // A description of the icon wasn't found in keywords.json file
                     Console.WriteLine($"Warning: Codepoint {name}={glyph} does not have a matching icon entry");
-                    continue;
+                    entry = new IconEntry() { Key = name + (isFilled ? "-f" : "") };
+                    iconEntries.Add(entry);
                 }
                 entry.Glyph = glyph;
             }

--- a/Tools/ResourceGenerator/Program.cs
+++ b/Tools/ResourceGenerator/Program.cs
@@ -231,10 +231,12 @@ void GenerateCalciteIconEnum(IList<IconEntry> icons, string filename, string _na
 
     foreach (var icon in icons.OrderBy(i=>i.Glyph))
     {   
-        string? alias = icon.Alias.Replace(Environment.NewLine, "");
+        string? alias = icon.Alias?.Replace(Environment.NewLine, "");
         iconsEnumOutput.WriteLine($"\t/// <summary>{icon.PrettyName}</summary>");
-        iconsEnumOutput.WriteLine($"\t/// <remarks>Category: {icon.Category}<br/>\n\t/// Alias: {alias}</remarks>");
-        iconsEnumOutput.WriteLine($"\t/// <release>{icon.Release}</release>");
+        if(!string.IsNullOrEmpty(icon.Category))
+            iconsEnumOutput.WriteLine($"\t/// <remarks>Category: {icon.Category}<br/>\n\t/// Alias: {alias}</remarks>");
+        if (!string.IsNullOrEmpty(icon.Release))
+            iconsEnumOutput.WriteLine($"\t/// <release>{icon.Release}</release>");
         iconsEnumOutput.WriteLine($"\t{icon.CSName} = {icon.Glyph},");
         iconsEnumOutput.WriteLine();
         iconsEnumOutput.Flush();

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -16,6 +16,9 @@
         <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
         <PackageLicenseFile>LICENSE.md</PackageLicenseFile>
         <CalciteUIIconsVersion>4.0.0</CalciteUIIconsVersion>
+        <PackageReleaseNotes>
+            - Added missing icons entries (Issue #3).
+        </PackageReleaseNotes>
     </PropertyGroup>
 
     <ItemGroup Condition="'$(IsPackable)'=='true'">

--- a/src/version.json
+++ b/src/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "0.1.0-preview1",
+  "version": "0.1.0-preview2",
   "publicReleaseRefSpec": [
     "^refs/tags/v\\d+\\.\\d+" // we release out of tags starting with vN.N
   ],


### PR DESCRIPTION
Icons that didn't have an entry in keywords was missing from the gene…rated list of icons.

If it's a filled icon, try and find description from the non-filled version and added 'filled' to the alias.
Otherwise just add entry without remarks and release-version info.

Added icons:
 - `AlertOffCircleFilled`
 - `BeginningFilled`
 - `BellFilled`
 - `CheckCircleFilled`
 - `CheckSquareFilled`
 - `CircleFilled`
 - `CirclePauseFilled`
 - `CircleStopFilled`
 - `ClosedCaptionFilled`
 - `EndFilled`
 - `ExclamationMarkCircleFilled`
 - `ExclamationMarkTriangleFilled`
 - `FlagFilled`
 - `ForwardFilled`
 - `GpsOnFilled`
 - `HeartFilled`
 - `InformationFilled`
 - `LockFilled`
 - `MinusCircleFilled`
 - `MinusSquareFilled`
 - `PauseFilled`
 - `PinTearFilled`
 - `PlayFilled`
 - `QuestionFilled`
 - `ReverseFilled`
 - `SquareFilled`
 - `StarFilled`
 - `StopSquareFilled`
 - `TranscriptFilled`
 - `WebAdaptor`
 - `XCircleFilled`
 - `XOctagonFilled`


Fixes #3