### PR TITLE
Ian/wpf tooltip default

### DIFF
--- a/src/Esri.Calcite.Wpf/Controls/ToolTip.xaml
+++ b/src/Esri.Calcite.Wpf/Controls/ToolTip.xaml
@@ -3,6 +3,8 @@
         <Setter Property="OverridesDefaultStyle" Value="true" />
         <Setter Property="HasDropShadow" Value="True" />
         <Setter Property="Foreground" Value="{DynamicResource CalciteText1Brush}" />
+        <Setter Property="Background" Value="{DynamicResource CalciteBackgroundBrush}" />
+        <Setter Property="BorderBrush" Value="{DynamicResource CalciteBrandPressBrush}" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="ToolTip">
@@ -11,8 +13,8 @@
                         Width="{TemplateBinding Width}"
                         Height="{TemplateBinding Height}"
                         Margin="8"
-                        Background="{DynamicResource CalciteBackgroundBrush}"
-                        BorderBrush="{DynamicResource CalciteBrandPressBrush}"
+                        Background="{TemplateBinding Background}"
+                        BorderBrush="{TemplateBinding BorderBrush}"
                         BorderThickness="1">
                         <Border.Effect>
                             <DropShadowEffect

--- a/src/Esri.Calcite.Wpf/Controls/ToolTip.xaml
+++ b/src/Esri.Calcite.Wpf/Controls/ToolTip.xaml
@@ -2,6 +2,7 @@
     <Style x:Key="CalciteToolTipStyle" TargetType="ToolTip">
         <Setter Property="OverridesDefaultStyle" Value="true" />
         <Setter Property="HasDropShadow" Value="True" />
+        <Setter Property="Foreground" Value="{DynamicResource CalciteText1Brush}" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="ToolTip">
@@ -34,5 +35,4 @@
             </Setter.Value>
         </Setter>
     </Style>
-
 </ResourceDictionary>


### PR DESCRIPTION
The WPF ToolTip style does not define a default Foreground color, and so inherits the Foreground of its parent element. This can cause readability issues from implicit styles set on parents. This branch sets a default ToolTip Foreground color.

This branch also makes the ToolTip Background and Border properties accessible on ToolTip.

Here is a simple UI to compare ToolTip behavior in main vs in this branch.
```
<Window.Resources>
    <Style TargetType="Button">
        <Setter Property="Foreground" Value="White" />
        <Setter Property="Background" Value="#444444" />
    </Style>
</Window.Resources>
<StackPanel>
    <Button Content="Style Foreground and Background Only"
            ToolTip="This is a tooltip" />
    <Button Content="Manual Button Foreground and Background"
                Foreground="Yellow"
                Background="Black"
                ToolTip="This is another tooltip with a manual button foreground and background" />
    <Button Content="Manual Tooltip Foreground and Background">
        <Button.ToolTip>
            <ToolTip Foreground="LightGreen"
                     Background="Brown"
                     BorderBrush="Pink"
                     Content="This is a manual tooltip background brown, border pink, and foreground light green" />
        </Button.ToolTip>
    </Button>
</StackPanel>
```