### PR TITLE
Fix WPF layout invalidation loop in Calcite ScrollViewer

### DIFF
--- a/src/Esri.Calcite.Wpf/Controls/ScrollBar.xaml
+++ b/src/Esri.Calcite.Wpf/Controls/ScrollBar.xaml
@@ -22,7 +22,7 @@
                             <Setter TargetName="Arrow" Property="Fill" Value="{DynamicResource CalciteBrandBrush}" />
                         </Trigger>
                         <Trigger Property="IsEnabled" Value="False">
-                            <Setter Property="Opacity" Value="0" />
+                            <Setter Property="Opacity" Value="0.3" />
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>

--- a/src/Esri.Calcite.Wpf/Controls/ScrollBar.xaml
+++ b/src/Esri.Calcite.Wpf/Controls/ScrollBar.xaml
@@ -208,14 +208,6 @@
                             Value="{TemplateBinding HorizontalOffset}" />
 
                     </Grid>
-                    <ControlTemplate.Triggers>
-                        <Trigger Property="ScrollableHeight" Value="0">
-                            <Setter TargetName="PART_VerticalScrollBar" Property="Visibility" Value="Collapsed" />
-                        </Trigger>
-                        <Trigger Property="ScrollableWidth" Value="0">
-                            <Setter TargetName="PART_HorizontalScrollBar" Property="Visibility" Value="Collapsed" />
-                        </Trigger>
-                    </ControlTemplate.Triggers>
                 </ControlTemplate>
             </Setter.Value>
         </Setter>


### PR DESCRIPTION
This fixes a WPF render/layout crash that appears in BasemapGallerySample only after Calcite styling is applied.

The issue is in the Calcite ScrollViewer template. The vertical scrollbar visibility is being controlled twice: once by WPF’s computed visibility and again by an extra ScrollableHeight == 0 trigger. In BasemapGallery grid mode, the item layout wraps based on available width. When the vertical scrollbar appears or disappears, that width changes, the wrapping changes, and the content height changes again. That can create a layout feedback loop and eventually trigger the WPF TimeManager invalidation exception.

The crash is difficult to reproduce in a reduced standalone sample as I think it depends on a very specific resize sequence and layout geometry. The BasemapGallery repro is the reliable one: switch to grid view, select a basemap, collapse the width to zero, then expand it again.

https://github.com/user-attachments/assets/1f6fe46d-0cfb-49dd-a896-3eb5bc9fc1d0




The fix removes the redundant vertical zero-extent trigger and lets WPF’s computed scrollbar visibility remain the single source of truth. That preserves the Calcite styling behavior and stops the layout oscillation.