### PR TITLE
Fix fonts not being embedded on WPF net472 and when packed locally on Maui

### DIFF
--- a/.github/workflows/CIBuild.yml
+++ b/.github/workflows/CIBuild.yml
@@ -24,7 +24,12 @@ jobs:
     
     - name: Setup Visual Studio Command Prompt
       uses: microsoft/setup-msbuild@v2.0.0
-        
+
+    - name: Setup .NET 10.x
+      uses: actions/setup-dotnet@v5.4.0
+      with:
+        dotnet-version: '10.0.302'
+
     - name: Build WPF
       run: |
         msbuild /restore /t:Build src\Esri.Calcite.WPF\Esri.Calcite.WPF.csproj /p:Configuration=Release

--- a/.github/workflows/CIBuild.yml
+++ b/.github/workflows/CIBuild.yml
@@ -24,12 +24,7 @@ jobs:
     
     - name: Setup Visual Studio Command Prompt
       uses: microsoft/setup-msbuild@v2.0.0
-
-    - name: Setup .NET 10.x
-      uses: actions/setup-dotnet@v5.4.0
-      with:
-        dotnet-version: '10.0.302'
-
+        
     - name: Build WPF
       run: |
         msbuild /restore /t:Build src\Esri.Calcite.WPF\Esri.Calcite.WPF.csproj /p:Configuration=Release

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -32,7 +32,7 @@
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
         <PackageReference Include="Nerdbank.GitVersioning" Version="3.7.115" PrivateAssets="all" />
     </ItemGroup>
-      <Target Name="DownloadFonts" Condition="!Exists('$(MSBuildThisFileDirectory)..\fonts\esri-calcite-ui-icons\$(CalciteUIIconsVersion)\package\fonts')">
+      <Target Name="DownloadFonts" Condition="!Exists('$(MSBuildThisFileDirectory)..\fonts\$(CalciteUIIconsVersion)\package\fonts')">
         <PropertyGroup>
             <CalciteUIIconsReleaseUrl>https://github.com/Esri/calcite-design-system/releases/download/%40esri%2Fcalcite-ui-icons%40$(CalciteUIIconsVersion)/esri-calcite-ui-icons-$(CalciteUIIconsVersion).tgz</CalciteUIIconsReleaseUrl>
         </PropertyGroup>

--- a/src/Esri.Calcite.Maui/Esri.Calcite.Maui.csproj
+++ b/src/Esri.Calcite.Maui/Esri.Calcite.Maui.csproj
@@ -16,8 +16,10 @@
         </PackageReleaseNotes>
     </PropertyGroup>
 
-    <ItemGroup>    
-      <None Include="$(MSBuildThisFileDirectory)..\..\fonts\$(CalciteUIIconsVersion)\package\fonts\*.ttf" Pack="True" PackagePath="Resources/Fonts/" Link="Resources\Fonts\%(Filename)%(Extension)" />
+    <ItemGroup>
+      <None Include="$(MSBuildThisFileDirectory)..\..\fonts\$(CalciteUIIconsVersion)\package\fonts\calcite-ui-icons-16.ttf" Pack="True" PackagePath="Resources\Fonts" Link="Resources\Fonts\calcite-ui-icons-16.ttf" />
+      <None Include="$(MSBuildThisFileDirectory)..\..\fonts\$(CalciteUIIconsVersion)\package\fonts\calcite-ui-icons-24.ttf" Pack="True" PackagePath="Resources\Fonts" Link="Resources\Fonts\calcite-ui-icons-24.ttf" />
+      <None Include="$(MSBuildThisFileDirectory)..\..\fonts\$(CalciteUIIconsVersion)\package\fonts\calcite-ui-icons-32.ttf" Pack="True" PackagePath="Resources\Fonts" Link="Resources\Fonts\calcite-ui-icons-32.ttf" />
       <Compile Include="..\..\GeneratedResources\Maui\*.cs" Link="GeneratedResources\%(RecursiveDir)%(Filename)%(Extension)" />
       <None Include="README.txt" Pack="True" PackagePath="\" />
       <None Include="..\..\docs\maui.md" Link="README.md" Pack="True" PackagePath="\README.md" />

--- a/src/Esri.Calcite.Wpf/Esri.Calcite.WPF.csproj
+++ b/src/Esri.Calcite.Wpf/Esri.Calcite.WPF.csproj
@@ -13,7 +13,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Resource Include="$(MSBuildThisFileDirectory)..\..\fonts\$(CalciteUIIconsVersion)\package\fonts\*.ttf" Link="Fonts\%(Filename)%(Extension)" />
+    <Resource Include="$(MSBuildThisFileDirectory)..\..\fonts\$(CalciteUIIconsVersion)\package\fonts\calcite-ui-icons-16.ttf" Link="Fonts\calcite-ui-icons-16.ttf" />
+    <Resource Include="$(MSBuildThisFileDirectory)..\..\fonts\$(CalciteUIIconsVersion)\package\fonts\calcite-ui-icons-24.ttf" Link="Fonts\calcite-ui-icons-24.ttf" />
+    <Resource Include="$(MSBuildThisFileDirectory)..\..\fonts\$(CalciteUIIconsVersion)\package\fonts\calcite-ui-icons-32.ttf" Link="Fonts\calcite-ui-icons-32.ttf" />
     <None Include="README.txt" Pack="True" PackagePath="\" />
     <None Include="..\..\docs\wpf.md" Link="README.md" Pack="True" PackagePath="\README.md" />
     <Page Include="..\..\GeneratedResources\WPF\**\*.xaml" Link="%(RecursiveDir)\%(Filename).xaml">

--- a/src/Esri.Calcite.Wpf/Esri.Calcite.WPF.csproj
+++ b/src/Esri.Calcite.Wpf/Esri.Calcite.WPF.csproj
@@ -24,6 +24,6 @@
     <Compile Include="..\..\GeneratedResources\Wpf\*.cs" Link="%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
 
-  <Target Name="GetResources" BeforeTargets="Restore" DependsOnTargets="DownloadFonts"/>
+  <Target Name="GetResources" BeforeTargets="MainResourcesGeneration" DependsOnTargets="DownloadFonts" />
 
 </Project>

--- a/src/Esri.Calcite.Wpf/Esri.Calcite.WPF.csproj
+++ b/src/Esri.Calcite.Wpf/Esri.Calcite.WPF.csproj
@@ -13,7 +13,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <Resource Include="$(MSBuildThisFileDirectory)..\..\fonts\$(CalciteUIIconsVersion)\package\fonts\*.ttf" Link="Fonts\%(Filename)%(Extension)" />
     <None Include="README.txt" Pack="True" PackagePath="\" />
     <None Include="..\..\docs\wpf.md" Link="README.md" Pack="True" PackagePath="\README.md" />
     <Page Include="..\..\GeneratedResources\WPF\**\*.xaml" Link="%(RecursiveDir)\%(Filename).xaml">
@@ -22,6 +21,14 @@
     <Compile Include="..\..\GeneratedResources\Wpf\*.cs" Link="%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
 
-  
-  <Target Name="GetResources" BeforeTargets="Build" DependsOnTargets="DownloadFonts" />
+  <!-- Run DownloadFonts before parallel framework builds are dispatched to avoid locked file errors. -->
+  <Target Name="GetResources" BeforeTargets="DispatchToInnerBuilds" DependsOnTargets="DownloadFonts"/>
+
+  <Target Name="SetFontPaths" BeforeTargets="PrepareForBuild">
+    <ItemGroup>
+      <Resource Include="$(MSBuildThisFileDirectory)..\..\fonts\$(CalciteUIIconsVersion)\package\fonts\calcite-ui-icons-16.ttf" Link="Fonts\calcite-ui-icons-16.ttf" />
+      <Resource Include="$(MSBuildThisFileDirectory)..\..\fonts\$(CalciteUIIconsVersion)\package\fonts\calcite-ui-icons-24.ttf" Link="Fonts\calcite-ui-icons-24.ttf" />
+      <Resource Include="$(MSBuildThisFileDirectory)..\..\fonts\$(CalciteUIIconsVersion)\package\fonts\calcite-ui-icons-32.ttf" Link="Fonts\calcite-ui-icons-32.ttf" />
+    </ItemGroup>
+  </Target>
 </Project>

--- a/src/Esri.Calcite.Wpf/Esri.Calcite.WPF.csproj
+++ b/src/Esri.Calcite.Wpf/Esri.Calcite.WPF.csproj
@@ -24,7 +24,6 @@
     <Compile Include="..\..\GeneratedResources\Wpf\*.cs" Link="%(RecursiveDir)%(Filename)%(Extension)" />
   </ItemGroup>
 
-  <!-- Run DownloadFonts before parallel framework builds are dispatched to avoid locked file errors. -->
-  <Target Name="GetResources" BeforeTargets="Restore;DispatchToInnerBuild" DependsOnTargets="DownloadFonts"/>
+  <Target Name="GetResources" BeforeTargets="Restore" DependsOnTargets="DownloadFonts"/>
 
 </Project>

--- a/src/Esri.Calcite.Wpf/Esri.Calcite.WPF.csproj
+++ b/src/Esri.Calcite.Wpf/Esri.Calcite.WPF.csproj
@@ -13,6 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Resource Include="$(MSBuildThisFileDirectory)..\..\fonts\$(CalciteUIIconsVersion)\package\fonts\*.ttf" Link="Fonts\%(Filename)%(Extension)" />
     <None Include="README.txt" Pack="True" PackagePath="\" />
     <None Include="..\..\docs\wpf.md" Link="README.md" Pack="True" PackagePath="\README.md" />
     <Page Include="..\..\GeneratedResources\WPF\**\*.xaml" Link="%(RecursiveDir)\%(Filename).xaml">
@@ -22,13 +23,6 @@
   </ItemGroup>
 
   <!-- Run DownloadFonts before parallel framework builds are dispatched to avoid locked file errors. -->
-  <Target Name="GetResources" BeforeTargets="DispatchToInnerBuilds" DependsOnTargets="DownloadFonts"/>
+  <Target Name="GetResources" BeforeTargets="Restore;DispatchToInnerBuild" DependsOnTargets="DownloadFonts"/>
 
-  <Target Name="SetFontPaths" BeforeTargets="PrepareForBuild">
-    <ItemGroup>
-      <Resource Include="$(MSBuildThisFileDirectory)..\..\fonts\$(CalciteUIIconsVersion)\package\fonts\calcite-ui-icons-16.ttf" Link="Fonts\calcite-ui-icons-16.ttf" />
-      <Resource Include="$(MSBuildThisFileDirectory)..\..\fonts\$(CalciteUIIconsVersion)\package\fonts\calcite-ui-icons-24.ttf" Link="Fonts\calcite-ui-icons-24.ttf" />
-      <Resource Include="$(MSBuildThisFileDirectory)..\..\fonts\$(CalciteUIIconsVersion)\package\fonts\calcite-ui-icons-32.ttf" Link="Fonts\calcite-ui-icons-32.ttf" />
-    </ItemGroup>
-  </Target>
 </Project>

--- a/src/TestApps/MauiTests/MauiTests.csproj
+++ b/src/TestApps/MauiTests/MauiTests.csproj
@@ -50,8 +50,8 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="10.0.0" />
-        <PackageReference Include="Microsoft.Maui.Controls" Version="10.0.90" />
+          <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="10.0.0" />
+          <PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/TestApps/MauiTests/MauiTests.csproj
+++ b/src/TestApps/MauiTests/MauiTests.csproj
@@ -51,13 +51,15 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="10.0.0" />
-        <PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
+        <PackageReference Include="Microsoft.Maui.Controls" Version="10.0.90" />
 	</ItemGroup>
 
 	<ItemGroup>
 	  <ProjectReference Include="..\..\Esri.Calcite.Maui\Esri.Calcite.Maui.csproj" />
-        <!-- This is normally done by the nuget.package build.targets file, but instead we simulate it here so project references work '-->
-        <MauiFont Include="$(MSBuildThisFileDirectory)..\..\..\fonts\$(CalciteUIIconsVersion)\package\fonts\*.ttf" Link="Resources\Fonts\%(Filename)%(Extension)" />
+	  <!-- This is normally done by the nuget.package build.targets file, but instead we simulate it here so project references work -->
+      <MauiFont Include="$(MSBuildThisFileDirectory)..\..\..\fonts\$(CalciteUIIconsVersion)\package\fonts\calcite-ui-icons-16.ttf" Link="Resources\Fonts\calcite-ui-icons-16.ttf" />
+      <MauiFont Include="$(MSBuildThisFileDirectory)..\..\..\fonts\$(CalciteUIIconsVersion)\package\fonts\calcite-ui-icons-24.ttf" Link="Resources\Fonts\calcite-ui-icons-24.ttf" />
+      <MauiFont Include="$(MSBuildThisFileDirectory)..\..\..\fonts\$(CalciteUIIconsVersion)\package\fonts\calcite-ui-icons-32.ttf" Link="Resources\Fonts\calcite-ui-icons-32.ttf" />
     </ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
It seems that on fresh builds msbuild was resolving the fonts wildcard path before the fonts were actually downloaded which made it silently fail to package any of the ttf files.

This was only happening for the net472 build. Presumably the net6.0 build was running just long enough after net472 that the fonts were in their correct places by the time it did its path resolution.

On Maui the package process was working fine on the ci runs but locally was not resolving properly for the same reason. In the maui case it seems to be able to retroactively resolve the file paths during the pack step as long as they are defined explicitly.